### PR TITLE
Sum and binary reduction

### DIFF
--- a/aten/src/ATen/native/ReduceOps.cpp
+++ b/aten/src/ATen/native/ReduceOps.cpp
@@ -260,6 +260,7 @@ Tensor& sum_out(Tensor& result, const Tensor& self, IntArrayRef dim,
   if (iter.numel() == 0) {
     result.zero_();
   } else {
+    result.zero_();
     sum_stub(iter.device_type(), iter);
   }
   return result;

--- a/aten/src/ATen/native/hammerblade/OffloadIter.h
+++ b/aten/src/ATen/native/hammerblade/OffloadIter.h
@@ -18,6 +18,71 @@ namespace native {
 void offload_iterator_op_impl(TensorIterator& iter, std::vector<eva_t> device_scalars,
     const char* kernel, uint32_t ntensors);
 
+//=======================================================================
+// Offloading operations that use reduction TensorIterator
+//=======================================================================
+
+template<typename scalar_type>
+void offload_iterator_reduce_op_impl(TensorIterator& iter, const char* kernel) {
+  TORCH_INTERNAL_ASSERT(iter.can_use_32bit_indexing());
+  TORCH_INTERNAL_ASSERT(iter.ntensors() == 2);
+  TORCH_CHECK(iter.noutputs() == 1,
+              "HB only support reduction with single output as of now");
+
+  // Device pointers to tensors on the device
+  std::vector<eva_t> device_args;
+  std::vector<eva_t> device_ptrs;
+
+  auto N = (uint32_t) iter.numel();
+
+  auto shape = iter.shape();
+
+  int64_t* sizes = (int64_t*) malloc(iter.ndim() * sizeof(int64_t));
+  TORCH_INTERNAL_ASSERT(sizes, "HB memory allocation failed on host");
+  for(int i = 0; i < iter.ndim(); ++i) {
+    sizes[i] = (int64_t) shape[i];
+  }
+
+  uint32_t size0 = sizes[0];
+
+  for(uint32_t i=0; i<iter.ntensors(); ++i) {
+    uint32_t n;
+
+    auto iter_strides = iter.strides(i);
+    int64_t* strides = (int64_t*) malloc(iter.ndim() * sizeof(int64_t));
+    TORCH_INTERNAL_ASSERT(strides, "HB memory allocation failed on host");
+    for(int j = 0; j < iter.ndim(); ++j) {
+      // iterator strides are in bytes, so divide by data size
+      strides[j] = (int64_t) (iter_strides[j] / sizeof(scalar_type));
+    }
+
+    if(i == 0) {
+      // output tensor
+      n = iter.num_output_elements();
+      sizes[0] = 1;
+    } else {
+      n = N;
+      sizes[0] = size0;
+    }
+
+    eva_t device_arg = create_device_tensor(
+        n, iter.ndim(),
+        (const int64_t*)strides, (const int64_t*)sizes, iter.data_ptr(i), device_ptrs);
+    device_args.push_back(device_arg);
+    free(strides);
+  }
+  device_args.push_back(create_device_scalar((uint32_t)iter.num_reduce_dims()));
+
+  free(sizes);
+
+  c10::hammerblade::offload_kernel(kernel, device_args);
+
+  // Need to deallocate those args on device
+  cleanup_device(device_args, device_ptrs);
+
+  iter.cast_outputs();
+}
+
 //============================================
 // TensorIterator operations with zero scalar
 //============================================

--- a/aten/src/ATen/native/hammerblade/Sum.cpp
+++ b/aten/src/ATen/native/hammerblade/Sum.cpp
@@ -1,0 +1,24 @@
+#include <cmath>
+#include <ATen/Dispatch.h>
+#include <ATen/native/ReduceOps.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/hammerblade/Offload.h>
+
+namespace at { namespace native {
+namespace {
+
+void sum_kernel_hb(TensorIterator& iter) {
+  AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "sum_hb", [&]() {
+      if(iter.num_output_elements() == 1) {
+        offload_op_unary(iter, "tensorlib_sum_simple");
+      } else {
+        offload_iterator_reduce_op_impl<scalar_t>(iter, "tensorlib_sum");
+      }
+  });
+}
+
+} // anonymous namespace
+
+REGISTER_HAMMERBLADE_DISPATCH(sum_stub, &sum_kernel_hb);
+
+}} // namespace at::native

--- a/hammerblade/torch/kernel/hb_reduction.hpp
+++ b/hammerblade/torch/kernel/hb_reduction.hpp
@@ -1,11 +1,104 @@
 #ifndef _HB_REDUCTION_H
 #define _HB_REDUCTION_H
 
+#include <brg_element_for.hpp>
+
+//====================================================================
+// Reduction mode used in LossNLL and other loss functions
+//====================================================================
+
 enum Reduction {
   None,             // Do not reduce
   Mean,             // (Possibly weighted) mean of losses
   Sum,              // Sum losses
   END
 };
+
+//====================================================================
+// Binary reductions -- sum, mean, etc.
+//
+// ndim -> number of dims in reduction iterator -- this may not equal
+//         to the input shape
+// num_reduction_dim -> number of dims to be reduced
+// elements_per_output -> how many input elements to create one output
+// reduce -> how to process a new input element
+// project -> how to do postprocessing on result
+//
+// 04/02/2020 Bandhav Veluri and Lin Cheng
+//====================================================================
+
+// Potential cases:
+// 1D input -- 1 reduction dim -- trivial
+// 2D input -- 1 reduction dim
+// 2D input -- 2 reduction dim -- trivial
+// 3D input -- 1 reduction dim
+// 3D input -- 2 reduction dim
+// 3D input -- 3 reduction dim -- trivial
+// 4D input -- 1 reduction dim
+// 4D input -- 2 reduction dim
+// 4D input -- 3 reduction dim
+// 4D input -- 4 reduction dim -- trivial
+
+template<typename scalar_t, typename F1, typename F2>
+inline void binary_reduction(BSGTensor<scalar_t>out,
+                             BSGTensor<scalar_t>in,
+                             uint32_t ndim, uint32_t num_reduction_dim,
+                             uint32_t elements_per_output,
+                             F1 reduce, F2 project) {
+  switch(ndim) {
+    case 1:
+      bsg_assert_msg(false, "1d case should be handled by reduction_simple");
+      break;
+    case 2:
+      if(num_reduction_dim == 1) {
+        // 2D input -- 1 reduction dim
+        // parallelize over output elements
+        brg_tile_for(out.numel(), [&](size_t n) {
+          // reduction result init to 0
+          scalar_t result = 0;
+          for(size_t d = 0; d < elements_per_output; d++) {
+            reduce(result, in(d, n));
+          }
+          out(0, n) = project(result);
+        });
+      } else {
+        bsg_assert_msg(false, "Invalid number of reduction dims");
+      }
+      break;
+    case 3:
+      if(num_reduction_dim == 1) {
+        // 3D input -- 1 reduction dim
+        // parallelize over output elements
+        brg_tile_for(out.numel(), [&](size_t n) {
+          // reduction result init to 0
+          scalar_t result = 0;
+          uint32_t dim1 = n / in.dim(2);
+          uint32_t dim2 = n % in.dim(2);
+          for(size_t d = 0; d < elements_per_output; d++) {
+            reduce(result, in(d, dim1, dim2));
+          }
+          out(0, dim1, dim2) = project(result);
+        });
+      } else if(num_reduction_dim == 2) {
+        // 3D input -- 2 reduction dim
+        // parallelize over output elements
+        brg_tile_for(out.numel(), [&](size_t n) {
+          // reduction result init to 0
+          scalar_t result = 0;
+          for(size_t d = 0; d < elements_per_output; d++) {
+            uint32_t dim0 = d / in.dim(1);
+            uint32_t dim1 = d % in.dim(1);
+            reduce(result, in(dim0, dim1, n));
+          }
+          out(0, 0, n) = project(result);
+        });
+      } else {
+        bsg_assert_msg(false, "Invalid number of reduction dims");
+      }
+      break;
+    default:
+      bsg_assert_msg(false, "Invalid number of dims for reduction kernel");
+  }
+}
 
 #endif

--- a/hammerblade/torch/kernel/kernel_sum.cpp
+++ b/hammerblade/torch/kernel/kernel_sum.cpp
@@ -1,0 +1,76 @@
+//====================================================================
+// Sum reduction kernel
+// 03/30/2020 Bandhav Veluri and Lin Cheng
+//====================================================================
+
+#include <kernel_common.hpp>
+#include <hb_reduction.hpp>
+
+// We wrap all external-facing C++ kernels with `extern "C"` to
+// prevent name mangling
+
+
+extern "C" {
+
+  __attribute__ ((noinline))  int tensorlib_sum(
+          bsg_tensor_t* out_,
+          bsg_tensor_t* in_,
+          uint32_t* num_reduction_dim_p) {
+    auto out = BSGTensor<float>(out_);
+    auto in = BSGTensor<float>(in_);
+    uint32_t num_reduction_dim = *num_reduction_dim_p;
+    auto ndim = in.ndim();
+
+    bsg_cuda_print_stat_kernel_start();
+
+    // there could be more than 1 dims
+    uint32_t elements_to_collect = in.dim(0);
+    for(auto i = 1; i < num_reduction_dim; i++) {
+      elements_to_collect *= in.dim(i);
+    }
+
+    auto reduce = [](float& partial_result, float input) {
+                    partial_result += input;
+                  };
+
+    auto project = [](float result) {
+                    return result;
+                   };
+
+    binary_reduction(out, in, ndim, num_reduction_dim,
+          elements_to_collect, reduce, project);
+
+    bsg_cuda_print_stat_kernel_end();
+    return 0;
+  }
+
+  HB_EMUL_REG_KERNEL(tensorlib_sum, bsg_tensor_t*, bsg_tensor_t*, uint32_t*)
+
+
+// 1D input -- 1 reduction dim -- trivial
+// 2D input -- 2 reduction dim -- trivial
+// 3D input -- 3 reduction dim -- trivial
+// 4D input -- 4 reduction dim -- trivial
+
+  __attribute__ ((noinline))  int tensorlib_sum_simple(
+          bsg_tensor_t* t0_p,
+          bsg_tensor_t* t1_p) {
+    uint32_t input_stride = *(uint32_t*)((intptr_t)t1_p->strides);
+    intptr_t output_base_p  = (intptr_t)t0_p->data;
+    intptr_t input_base_p  = (intptr_t)t1_p->data;
+    float sum_ = 0.0f;
+    bsg_cuda_print_stat_kernel_start();
+    if (__bsg_id == 0) {
+      for(size_t i = 0; i < t1_p->N; i++) {
+        sum_ += *(float*)(input_base_p);
+        input_base_p += input_stride;
+      }
+      *(float*)(output_base_p) += sum_;
+    }
+    bsg_cuda_print_stat_kernel_end();
+    return 0;
+  }
+
+  HB_EMUL_REG_KERNEL(tensorlib_sum_simple, bsg_tensor_t*, bsg_tensor_t*);
+
+}

--- a/hammerblade/torch/tests/test_sum.py
+++ b/hammerblade/torch/tests/test_sum.py
@@ -150,3 +150,12 @@ def test_torch_sum_28():
     sum_ = torch.sum(h, (0, 2), keepdim=True)
     assert sum_.device == torch.device("hammerblade")
     assert torch.allclose(sum_.cpu(), torch.sum(x, (0, 2), keepdim=True))
+
+def test_torch_sum_29():
+    x = torch.rand(2, 3, 4, 5)
+    _test_torch_sum(x)
+
+def test_torch_sum_30():
+    x = torch.rand(2, 3, 4, 5)
+    for dim in range(4):
+        _test_torch_sum(x, dim=dim)

--- a/hammerblade/torch/tests/test_sum.py
+++ b/hammerblade/torch/tests/test_sum.py
@@ -1,0 +1,152 @@
+"""
+Unit tests for torch.sum
+03/29/2020 Lin Cheng (lc873@cornell.edu)
+"""
+
+import torch
+
+torch.manual_seed(42)
+
+def _test_torch_sum(tensor, dim=None, keepdim=False):
+    tensor_h = tensor.hammerblade()
+    if dim is None:
+        sum_ = torch.sum(tensor_h)
+        assert sum_.device == torch.device("hammerblade")
+        assert torch.allclose(sum_.cpu(), torch.sum(tensor))
+    else:
+        sum_ = torch.sum(tensor_h, dim, keepdim=keepdim)
+        assert sum_.device == torch.device("hammerblade")
+        assert torch.allclose(sum_.cpu(), torch.sum(tensor, dim, keepdim=keepdim))
+
+def test_torch_sum_1():
+    x = torch.ones(10)
+    _test_torch_sum(x)
+
+def test_torch_sum_2():
+    x = torch.ones(10)
+    _test_torch_sum(x, dim=0)
+
+def test_torch_sum_3():
+    x = torch.ones(10)
+    _test_torch_sum(x, dim=0, keepdim=True)
+
+def test_torch_sum_4():
+    x = torch.randn(3, 4)
+    _test_torch_sum(x)
+
+def test_torch_sum_5():
+    x = torch.randn(3, 4)
+    _test_torch_sum(x, dim=0)
+
+def test_torch_sum_6():
+    x = torch.randn(3, 4)
+    _test_torch_sum(x, dim=0, keepdim=True)
+
+def test_torch_sum_7():
+    x = torch.randn(3, 4)
+    _test_torch_sum(x, dim=1)
+
+def test_torch_sum_8():
+    x = torch.randn(3, 4)
+    _test_torch_sum(x, dim=1, keepdim=True)
+
+def test_torch_sum_9():
+    x = torch.randn(3, 4)
+    _test_torch_sum(x, dim=(0, 1))
+
+def test_torch_sum_10():
+    x = torch.randn(3, 4)
+    _test_torch_sum(x, dim=(0, 1), keepdim=True)
+
+def test_torch_sum_11():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x)
+
+def test_torch_sum_12():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=0)
+
+def test_torch_sum_13():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=0, keepdim=True)
+
+def test_torch_sum_14():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=1)
+
+def test_torch_sum_15():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=1, keepdim=True)
+
+def test_torch_sum_16():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=2)
+
+def test_torch_sum_17():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=2, keepdim=True)
+
+def test_torch_sum_18():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=(0, 1))
+
+def test_torch_sum_19():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=(0, 1), keepdim=True)
+
+def test_torch_sum_20():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=(1, 2))
+
+def test_torch_sum_21():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=(1, 2), keepdim=True)
+
+def test_torch_sum_22():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=(0, 2))
+
+def test_torch_sum_23():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=(0, 2), keepdim=True)
+
+def test_torch_sum_24():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=(0, 1, 2))
+
+def test_torch_sum_25():
+    x = torch.randn(3, 4, 5)
+    _test_torch_sum(x, dim=(0, 1, 2), keepdim=True)
+
+def test_torch_sum_26():
+    x = torch.tensor([[[1.], [2.], [3.]]])
+    h = x.hammerblade()
+    x = x.expand(2, 3, 4)
+    h = h.expand(2, 3, 4)
+    assert h.device == torch.device("hammerblade")
+    assert not h.is_contiguous()
+    sum_ = torch.sum(h)
+    assert sum_.device == torch.device("hammerblade")
+    assert torch.allclose(sum_.cpu(), torch.sum(x))
+
+def test_torch_sum_27():
+    x = torch.tensor([[[1.], [2.], [3.]]])
+    h = x.hammerblade()
+    x = x.expand(2, 3, 4)
+    h = h.expand(2, 3, 4)
+    assert h.device == torch.device("hammerblade")
+    assert not h.is_contiguous()
+    sum_ = torch.sum(h, (0, 2))
+    assert sum_.device == torch.device("hammerblade")
+    assert torch.allclose(sum_.cpu(), torch.sum(x, (0, 2)))
+
+def test_torch_sum_28():
+    x = torch.tensor([[[1.], [2.], [3.]]])
+    h = x.hammerblade()
+    x = x.expand(2, 3, 4)
+    h = h.expand(2, 3, 4)
+    assert h.device == torch.device("hammerblade")
+    assert not h.is_contiguous()
+    sum_ = torch.sum(h, (0, 2), keepdim=True)
+    assert sum_.device == torch.device("hammerblade")
+    assert torch.allclose(sum_.cpu(), torch.sum(x, (0, 2), keepdim=True))


### PR DESCRIPTION
In this PR:
 - we can now do reduction on iterators that have at most 3D shapes.
 - implemented `torch.sum`

To use `binary_reduction`, we need to define 2 lambda functions:
 - `reduce` takes the partial result and an input element. it defines how to reduce an input element.
    For `sum`, reduce is `partial_result += input`
 - `project` takes in the reduced result and performs postprocessing. For `sum`, project returns the identity. But for `mean`, it returns `result /  num_elements_per_output`

This is a joint PR with @vb000 , so it would be great if @zzy82518996 could also take a look and review this one.