### PR TITLE
README fixes for emulation setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ This work aims to port PyTorch to HammerBlade.
 
 - Setup building environment variables:
 
-     cd hb-pytorch && source setup_emul_build_env.sh
+      cd hb-pytorch && source setup_emul_build_env.sh
 
 - Build PyTorch. This step can take up to 15 minutes:
 
-     python setup.py develop
+      python setup.py develop
 
 [venv]: https://docs.python.org/3/tutorial/venv.html
 

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ This work aims to port PyTorch to HammerBlade.
 
       git clone -b hb-device git@github.com:cornell-brg/hb-pytorch.git
 
-- Create a Python virtual environment:
+- Create a [Python virtual environment][venv]:
 
-      python3.6 -m venv ./venv_pytorch
-      python3.6 -m venv ./venv_pytorch
+      python3 -m venv ./venv_pytorch
+      source ./venv_pytorch/bin/activate
 
 - Install some dependencies:
 
@@ -46,6 +46,8 @@ This work aims to port PyTorch to HammerBlade.
 - Build PyTorch. This step can take up to 15 minutes:
 
      python setup.py develop
+
+[venv]: https://docs.python.org/3/tutorial/venv.html
 
 ### Run Pytests
  - Goto hb-pytorch directory

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This work aims to port PyTorch to HammerBlade.
 
 - Setup building environment variables:
 
-      cd hb-pytorch && source setup_emul_build_env.sh
+      source setup_emul_build_env.sh
 
 - Build PyTorch. This step can take up to 15 minutes:
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This work aims to port PyTorch to HammerBlade.
 
 - Clone this repository:
 
-      git clone -b hb-device git@github.com:cornell-brg/hb-pytorch.git
+      git clone git@github.com:cornell-brg/hb-pytorch.git
 
 - Create a [Python virtual environment][venv]:
 

--- a/README.md
+++ b/README.md
@@ -21,18 +21,32 @@ This work aims to port PyTorch to HammerBlade.
     `python setup.py install`
 
 ### How to build PyTorch with Emulation Layer
-    `git clone -b hb-device git@github.com:cornell-brg/hb-pytorch.git`
- - Create python virtual environment
-    `python3.6 -m venv ./venv_pytorch`
-    `python3.6 -m venv ./venv_pytorch`
- - Install dependencies
-    `pip install numpy pyyaml mkl mkl-include setuptools cmake cffi typing sklearn tqdm pytest ninja`
- - Init pytorch third party dependencies
-    `git submodule update --init --recursive`
- - Setup building environment variables.
-    `cd hb-pytorch && source setup_emul_build_env.sh`
- - Build pytorch. This step can take up to 15 minutes
-    `python setup.py develop`
+
+- Clone this repository:
+
+      git clone -b hb-device git@github.com:cornell-brg/hb-pytorch.git
+
+- Create a Python virtual environment:
+
+      python3.6 -m venv ./venv_pytorch
+      python3.6 -m venv ./venv_pytorch
+
+- Install some dependencies:
+
+      pip install numpy pyyaml mkl mkl-include setuptools cmake cffi typing sklearn tqdm pytest ninja
+
+- Init PyTorch third party dependencies:
+
+      git submodule update --init --recursive
+
+- Setup building environment variables:
+
+     cd hb-pytorch && source setup_emul_build_env.sh
+
+- Build PyTorch. This step can take up to 15 minutes:
+
+     python setup.py develop
+
 ### Run Pytests
  - Goto hb-pytorch directory
     `cd hb-pytorch/hammerblade/torch`


### PR DESCRIPTION
Hello! This tweaks a few things in the README for the emulation setup instructions.

- Fix Markdown formatting to use code blocks.
- Fix venv instructions to describe activation (instead of duplicating the same command twice).
- Fix a reference to a nonexistent branch in the `clone` command.
- Link to helpful background on venvs.
- Switch to `python3` instead of `python3.6` to be a tad more flexible.
- Remove a `cd` that is invalidated by the previous step—perhaps we need to add one back somewhere?
- English style tweaks.