### PR TITLE
Setup scripts: make -fuse-ld flag "optional"

### DIFF
--- a/setup_cosim_build_env.sh
+++ b/setup_cosim_build_env.sh
@@ -16,8 +16,12 @@ export USE_QNNPACK=0
 export USE_DISTRIBUTED=0
 export USE_OPENMP=0
 export ATEN_THREADING=NATIVE
-export CFLAGS='-fuse-ld=gold'
 export OMP_NUM_THREADS=1
+
+# Use gold if it's available for faster linking.
+if which gold >/dev/null 2>&1 ; then
+    export CFLAGS='-fuse-ld=gold'
+fi
 
 # get current directory
 SOURCE="${BASH_SOURCE[0]}"

--- a/setup_emul_build_env.sh
+++ b/setup_emul_build_env.sh
@@ -15,8 +15,12 @@ export USE_QNNPACK=0
 export USE_DISTRIBUTED=0
 export USE_OPENMP=0
 export ATEN_THREADING=NATIVE
-export CFLAGS='-fuse-ld=gold'
 export OMP_NUM_THREADS=1
+
+# Use gold if it's available for faster linking.
+if which gold >/dev/null 2>&1 ; then
+    export CFLAGS='-fuse-ld=gold'
+fi
 
 # enable emulation layer building
 export USE_HB_EMUL=1


### PR DESCRIPTION
This is part of #40 (my effort to build hb-pytorch on macOS). The setup scripts include a CFLAGS setting to use [gold](https://en.wikipedia.org/wiki/Gold_(linker)) as the linker. In https://github.com/cornell-brg/hb-pytorch/issues/40#issuecomment-608623454, @vb000 clarified that this is just to make linking faster. These changes enable that flag only if the system actually has gold installed.