### PR TITLE
Add missing `#include <string>`

### DIFF
--- a/c10/hammerblade/emul/kernel_trampoline.h
+++ b/c10/hammerblade/emul/kernel_trampoline.h
@@ -18,6 +18,7 @@
 #include <vector>
 #include <cassert>
 #include <functional>
+#include <string>
 #include <bsg_manycore_errno.h>
 
 extern std::map<std::string, std::function<int(uint32_t, uint64_t*)>> kernelMap;


### PR DESCRIPTION
Part of #40. The `kernel_trampoline.h` header uses `std::string` but does not include the appropriate header. (Clang emits the obvious error; I am not sure why gcc does not complain.)