### PR TITLE
Remove illegal & unnecessary variable-length array initializer in addmm kernel

### DIFF
--- a/hammerblade/torch/kernel/kernel_addmm.cpp
+++ b/hammerblade/torch/kernel/kernel_addmm.cpp
@@ -59,7 +59,7 @@ extern "C" {
                 int res_dim_x = rc == m2_num_blk_per_col - 1 ? m2_last_blk_dim_x : BLOCK_DIM;
 
                 // initialize scratchpad result
-                float sp_result[res_dim_y][res_dim_x] = {};
+                float sp_result[res_dim_y][res_dim_x];
                 for (int i = 0; i < res_dim_y; i++) {
                     for (int j = 0; j < res_dim_x; j++) {
                     }

--- a/hammerblade/torch/kernel/kernel_addmm.cpp
+++ b/hammerblade/torch/kernel/kernel_addmm.cpp
@@ -62,6 +62,7 @@ extern "C" {
                 float sp_result[res_dim_y][res_dim_x];
                 for (int i = 0; i < res_dim_y; i++) {
                     for (int j = 0; j < res_dim_x; j++) {
+                        sp_result[i][j] = 0.0f;
                     }
                 }
 


### PR DESCRIPTION
Under Clang, variable-length arrays in C++ are not allowed to have initializers. (N.B. even in C99, which standardizes VLAs, [this kind of initialization is illegal](https://stackoverflow.com/a/52365995/39182).) Clang emits this error:

```
../hammerblade/torch/kernel/kernel_addmm.cpp:62:33: error: variable-sized object may not be initialized
                float sp_result[res_dim_y][res_dim_x] = {};
```

This PR just removes the initializer, which I *think* should be fine because this output array is "overwritten" anyway?

(Not terribly relevant here, but C99 VLAs in C++ are a GNU extension anyway and have [some pitfalls](https://stackoverflow.com/a/21519062/39182). I know they are the most convenient way to allocate space in the manycore's scratchpads, but in an ideal world, we'd be `malloc`ing these on the heap somehow—if it were possible to `malloc` in the scratchpad. (Maybe it already is?))

Part of #40.