### PR TITLE
Fix 1d reduction corner case

### DIFF
--- a/hammerblade/torch/kernel/hb_reduction.hpp
+++ b/hammerblade/torch/kernel/hb_reduction.hpp
@@ -47,7 +47,13 @@ inline void binary_reduction(BSGTensor<scalar_t>out,
                              F1 reduce, F2 project) {
   switch(ndim) {
     case 1:
-      bsg_assert_msg(false, "1d case should be handled by reduction_simple");
+      // There is this corner case, in which each output is produced by only
+      // one input element
+      bsg_assert_msg(out.numel() == in.numel(),
+                     "This case should be handled by reduction_simple?");
+      brg_tile_for(out.numel(), [&](size_t n) {
+        out(n) = project(in(n));
+      });
       break;
     case 2:
       if(num_reduction_dim == 1) {

--- a/hammerblade/torch/pytest_runner.py
+++ b/hammerblade/torch/pytest_runner.py
@@ -48,4 +48,4 @@ print(" starting pytest ...")
 print()
 
 # invoke pytest main loop
-pytest.main(pytest_argv + targets)
+exit(pytest.main(pytest_argv + targets))

--- a/hammerblade/torch/tests/test_sum.py
+++ b/hammerblade/torch/tests/test_sum.py
@@ -165,6 +165,10 @@ def test_torch_sum_31():
     _test_torch_sum(x, dim=0)
 
 def test_torch_sum_32():
+    x = torch.rand(1, 3, 4)
+    _test_torch_sum(x, dim=0)
+
+def test_torch_sum_33():
     x = torch.tensor([[1.]])
     h = x.hammerblade()
     x = x.expand(1, 10)

--- a/hammerblade/torch/tests/test_sum.py
+++ b/hammerblade/torch/tests/test_sum.py
@@ -159,3 +159,7 @@ def test_torch_sum_30():
     x = torch.rand(2, 3, 4, 5)
     for dim in range(4):
         _test_torch_sum(x, dim=dim)
+
+def test_torch_sum_31():
+    x = torch.rand(1, 10)
+    _test_torch_sum(x, dim=0)

--- a/hammerblade/torch/tests/test_sum.py
+++ b/hammerblade/torch/tests/test_sum.py
@@ -163,3 +163,14 @@ def test_torch_sum_30():
 def test_torch_sum_31():
     x = torch.rand(1, 10)
     _test_torch_sum(x, dim=0)
+
+def test_torch_sum_32():
+    x = torch.tensor([[1.]])
+    h = x.hammerblade()
+    x = x.expand(1, 10)
+    h = h.expand(1, 10)
+    assert h.device == torch.device("hammerblade")
+    assert not h.is_contiguous()
+    sum_ = torch.sum(h, 0, keepdim=True)
+    assert sum_.device == torch.device("hammerblade")
+    assert torch.allclose(sum_.cpu(), torch.sum(x, 0, keepdim=True))


### PR DESCRIPTION
BUG fixes:
 - fix the bug in which pytest failures are not communicated to TravisCI correctly
 - fix the bug in which in certain cases, each reduction output is computed with only one input element, and in such condition, the iterator has 1d shape. For example:
```
def test_torch_sum_31():
    x = torch.rand(1, 10)
    _test_torch_sum(x, dim=0)
```