### PR TITLE
README: Install hypothesis in the emulation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ This work aims to port PyTorch to HammerBlade.
 
 - Install some dependencies:
 
-      pip install numpy pyyaml mkl mkl-include setuptools cmake cffi typing sklearn tqdm pytest ninja
+      pip install numpy pyyaml mkl mkl-include setuptools cmake cffi typing sklearn tqdm pytest ninja hypothesis
 
 - Init PyTorch third party dependencies:
 


### PR DESCRIPTION
This adds `hypothesis` to the `pip install` line in the emulation instructions, as it already is in the cosim instructions.

Any interest in using [Poetry](https://python-poetry.org) to manage the virtualenv and dependencies? That would avoid the need to maintain separate lists of commands in the README, avoid requiring developers to copy & paste long commands like this, and combine the virtualenv creation and dependency installation into a single step.
