### PR TITLE
Workaround for HW WAW violation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -266,4 +266,4 @@ vanilla_operation_trace.csv
 vanilla_stats.csv
 vc_hdrs.h
 vcache_non_blocking_stats.log
-
+DVEfiles

--- a/hammerblade/torch/Makefile
+++ b/hammerblade/torch/Makefile
@@ -50,6 +50,11 @@ regression: kernel.riscv $(COSIM_EXE)
 $(COSIM_EXE):
 	$(MAKE) -C $(COSIM_PYTHON_DIR) $@
 
+ifeq ($(DEBUG),1)
+  RISCV_GXX_EXTRA_OPTS += -g
+  RISCV_LINK_OPTS += -g
+endif
+
 # Include BSG Manycore's builddefs
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master
 

--- a/hammerblade/torch/kernel/hb_hw_patch.hpp
+++ b/hammerblade/torch/kernel/hb_hw_patch.hpp
@@ -2,16 +2,16 @@
 #define _HB_HW_PATCH_HPP
 
 #ifndef HB_EMUL
-#define HB_RAW_HAZARD(var) \
-  do {                     \
-    asm volatile (         \
-        "mv %0, %1;"       \
-        : "=r" ((var))     \
-        : "r" ((var))      \
-        );                 \
+#define HB_FIX_WAW_HAZARD(var) \
+  do {                         \
+    asm volatile (             \
+        "mv %0, %1;"           \
+        : "=r" ((var))         \
+        : "r" ((var))          \
+        );                     \
   } while(0)
 #else
-#define HB_RAW_HAZARD(var)
+#define HB_FIX_WAW_HAZARD(var)
 #endif // ifndef HB_EMUL
 
 #endif // _HB_HW_PATCH_HPP

--- a/hammerblade/torch/kernel/hb_hw_patch.hpp
+++ b/hammerblade/torch/kernel/hb_hw_patch.hpp
@@ -1,0 +1,17 @@
+#ifndef _HB_HW_PATCH_HPP
+#define _HB_HW_PATCH_HPP
+
+#ifndef HB_EMUL
+#define HB_RAW_HAZARD(var) \
+  do {                     \
+    asm volatile (         \
+        "mv %0, %1;"       \
+        : "=r" ((var))     \
+        : "r" ((var))      \
+        );                 \
+  } while(0)
+#else
+#define HB_RAW_HAZARD(var)
+#endif // ifndef HB_EMUL
+
+#endif // _HB_HW_PATCH_HPP

--- a/hammerblade/torch/kernel/hb_hw_patch.hpp
+++ b/hammerblade/torch/kernel/hb_hw_patch.hpp
@@ -2,6 +2,11 @@
 #define _HB_HW_PATCH_HPP
 
 #ifndef HB_EMUL
+
+// Fixes WAW violations in HW
+//
+// WAW violations are seen in cosimulation as errors starting with:
+// [ERROR][VCORE] STALL_FORCE_WB WAW HAZARD
 #define HB_FIX_WAW_HAZARD(var) \
   do {                         \
     asm volatile (             \
@@ -10,8 +15,11 @@
         : "r" ((var))          \
         );                     \
   } while(0)
+
 #else
+
 #define HB_FIX_WAW_HAZARD(var)
+
 #endif // ifndef HB_EMUL
 
 #endif // _HB_HW_PATCH_HPP

--- a/hammerblade/torch/kernel/hb_hw_patch.hpp
+++ b/hammerblade/torch/kernel/hb_hw_patch.hpp
@@ -1,3 +1,40 @@
+// =============================================================
+// Workarounds for HB HW Issues
+//
+// This header file implementes a set of workarounds for HW
+// issues that might be discovered on ASIC. The plan is to
+// reproduce the bug in cosimulation and use verilog asserts
+// to root cause the line of kernel code triggering the bug.
+// After figuring out the line of kernel code triggering the
+// bug, the verilog error message can used to find the right
+// software fix in this header, and use fix that to patch the
+// kernel code.
+//
+// For example, if a bug is triggered by a WAW violation between:
+//
+//   sizes = (uint32_t*) ((intptr_t) t->sizes);
+//     204: 00c52f03            lw  x30,12(x10)
+//   .
+//   .
+// (and)
+//   .
+//   .
+//   strides[1] = (input.get_strides())[0];
+//     3ac: 00092f03            lw  x30,0(x18)
+// 
+// The error message by verilog assertion would start with:
+// [ERROR][VCORE] STALL_FORCE_WB WAW HAZARD
+//
+// A possible workaround is to use the macro HB_FIX_WAW_HAZARD
+// on `sizes`:
+//
+//   sizes = (uint32_t*) ((intptr_t) t->sizes);
+//   HB_FIX_WAW_HAZARD(sizes);
+//   .
+//   .
+//   strides[1] = (input.get_strides())[0];
+// =============================================================
+
 #ifndef _HB_HW_PATCH_HPP
 #define _HB_HW_PATCH_HPP
 

--- a/hammerblade/torch/kernel/kernel_common.hpp
+++ b/hammerblade/torch/kernel/kernel_common.hpp
@@ -18,6 +18,7 @@
 #include "hb_tensor.hpp"
 #include <hb_assert.hpp>
 #include <hb_parallel_for.hpp>
+#include <hb_hw_patch.hpp>
 
 //====================================================================
 // HammerBlade kernel emulation


### PR DESCRIPTION
- This adds a method for implementing workarounds for HW issues.
- In this case, this adds a macro to create a RAW hazard to force a dependency. It's used like this:
https://github.com/cornell-brg/hb-pytorch/blob/5d9feb353b7d81b010a199cef9a2c8527e1ac919/hammerblade/torch/kernel/kernel_copy_hb_to_hb.cpp#L21-L25