### PR TITLE
Propagate storage as void pointer for logging

### DIFF
--- a/aten/src/ATen/native/hammerblade/OffloadDef.h
+++ b/aten/src/ATen/native/hammerblade/OffloadDef.h
@@ -25,7 +25,7 @@ typedef struct {
   eva_t sizes;   // Pointer to sizes vector; number of sizes = dims
   eva_t data;    // Pointer to raw data
 #ifdef HB_ENABLE_KERNEL_LOG
-  float* storage_head;
+  void* storage_head;
   uint32_t storage_numel;
 #endif
 } hb_mc_tensor_t;

--- a/aten/src/ATen/native/hammerblade/OffloadIter.cpp
+++ b/aten/src/ATen/native/hammerblade/OffloadIter.cpp
@@ -50,7 +50,7 @@ void offload_iterator_op_impl(TensorIterator& iter, std::vector<eva_t> device_sc
     eva_t device_arg = create_device_tensor(N, iter.ndim(),
         (const int64_t*)local_strides, (const int64_t*)sizes, iter.data_ptr(i),
 #ifdef HB_ENABLE_KERNEL_LOG
-        iter.tensor(i).storage().data<float>(),
+        iter.tensor(i).storage().data(),
         iter.tensor(i).storage().numel(),
 #endif
         device_ptrs);

--- a/aten/src/ATen/native/hammerblade/OffloadIter.h
+++ b/aten/src/ATen/native/hammerblade/OffloadIter.h
@@ -69,7 +69,7 @@ void offload_iterator_reduce_op_impl(TensorIterator& iter, const char* kernel) {
         n, iter.ndim(),
         (const int64_t*)strides, (const int64_t*)sizes, iter.data_ptr(i),
 #ifdef HB_ENABLE_KERNEL_LOG
-        iter.tensor(i).storage().data<float>(),
+        iter.tensor(i).storage().data(),
         (uint32_t) iter.tensor(i).storage().numel(),
 #endif
         device_ptrs);

--- a/aten/src/ATen/native/hammerblade/OffloadUtils.cpp
+++ b/aten/src/ATen/native/hammerblade/OffloadUtils.cpp
@@ -42,7 +42,7 @@ eva_t create_device_tensor(uint32_t N, uint32_t dims,
                                   const int64_t* sizes,
                                   const void* data,
 #ifdef HB_ENABLE_KERNEL_LOG
-                                  float* storage_head,
+                                  void* storage_head,
                                   uint32_t storage_numel,
 #endif
                                   std::vector<eva_t>& device_ptrs) {
@@ -102,7 +102,7 @@ eva_t create_device_tensor(const Tensor& tensor,
   return create_device_tensor(
       N, dims, strides, sizes, data,
 #ifdef HB_ENABLE_KERNEL_LOG
-      tensor.storage().data<float>(),
+      (void*) tensor.storage().data(),
       (uint32_t) tensor.storage().numel(),
 #endif
       device_ptrs);

--- a/aten/src/ATen/native/hammerblade/OffloadUtils.h
+++ b/aten/src/ATen/native/hammerblade/OffloadUtils.h
@@ -21,7 +21,7 @@ eva_t create_device_tensor(uint32_t N, uint32_t dims,
                                   const int64_t* sizes,
                                   const void* data,
 #ifdef HB_ENABLE_KERNEL_LOG
-                                  float* storage_head,
+                                  void* storage_head,
                                   uint32_t storage_numel,
 #endif
                                   std::vector<eva_t>& device_ptrs);

--- a/c10/hammerblade/emul/kernel_logger.h
+++ b/c10/hammerblade/emul/kernel_logger.h
@@ -124,7 +124,7 @@ class KernelLogger {
       tensor_json["storage_head"] = (uint64_t) tensor->storage_head;
       tensor_json["strides"] = json_list(dims, strides);
       tensor_json["sizes"] = json_list(dims, sizes);
-      tensor_json["storage"] = json_list(storage_numel, tensor->storage_head);
+      tensor_json["storage"] = json_list(storage_numel, (float*) tensor->storage_head);
       log_json[curr_kernel].push_back(tensor_json);
     }
 

--- a/hammerblade/torch/kernel/hb_tensor.hpp
+++ b/hammerblade/torch/kernel/hb_tensor.hpp
@@ -42,7 +42,7 @@ typedef struct {
 
 // Info about storage objects
 #ifdef HB_ENABLE_KERNEL_LOG
-  float* storage_head;
+  void* storage_head;
   uint32_t storage_numel;
 #endif
 } hb_tensor_t;


### PR DESCRIPTION
This makes sure that log won't break when the tensor has data other than float.