### PR TITLE
Low-level Copy

### DIFF
--- a/aten/src/ATen/native/hammerblade/LLCopy.cpp
+++ b/aten/src/ATen/native/hammerblade/LLCopy.cpp
@@ -1,0 +1,39 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/native/Resize.h>
+#include <ATen/hammerblade/HammerBladeContext.h>
+
+namespace at {
+namespace native {
+
+Tensor llcopy_to_hb(const Tensor& self) {
+
+  // get low level storage size
+  size_t itemsize = self.storage().itemsize();
+  int64_t numel = self.storage().numel();
+  size_t storage_size = numel * itemsize;
+
+  // alloc on HB
+  c10::Allocator* allocator = at::hammerblade::getHammerBladeDeviceAllocator();
+
+  // device tensor reconstruction
+  auto storage_offset = self.storage_offset();
+  auto storage_impl = c10::make_intrusive<StorageImpl>(
+      self.dtype(),
+      numel,
+      allocator->allocate(storage_size),
+      allocator,
+      /*resizeable=*/true);
+  auto tensor = detail::make_tensor<TensorImpl>(std::move(storage_impl), at::TensorTypeId::HammerBladeTensorId);
+  setStrided(tensor, self.sizes(), self.strides(), storage_offset);
+
+  // memcpy
+  void* ptr = (void*)self.storage().data();
+  void* hb_ptr = (void*)tensor.storage().data();
+  c10::hammerblade::memcpy_host_to_device(hb_ptr, ptr, storage_size);
+
+  return tensor;
+
+}
+
+}} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -405,6 +405,11 @@
   use_c10_dispatcher: full
   variants: function, method
 
+- func: llcopy(Tensor self) -> Tensor
+  variants: function, method
+  dispatch:
+    CPU: llcopy_to_hb
+
 - func: as_strided(Tensor(a) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a)
   variants: function, method
   dispatch:

--- a/hammerblade/torch/tests/test_llcopy.py
+++ b/hammerblade/torch/tests/test_llcopy.py
@@ -1,0 +1,52 @@
+"""
+Tests on LLCopy
+05/01/2020 Lin Cheng (lc873@cornell.edu)
+"""
+
+import torch
+import random
+
+torch.manual_seed(42)
+random.seed(42)
+
+def _compare(x, h):
+    assert x.numel() == h.numel()
+    assert x.element_size() == h.element_size()
+    assert x.dtype == h.dtype
+    assert x.stride() == h.stride()
+    assert x.storage_offset() == h.storage_offset()
+    assert x.size() == h.size()
+    assert x.is_contiguous() == h.is_contiguous()
+    assert h.device == torch.device("hammerblade")
+    assert torch.equal(h.cpu(), x)
+
+def test_llcopy_1():
+    x = torch.ones(10)
+    h = x.hammerblade_ll()
+    _compare(x, h)
+
+def test_llcopy_2():
+    x = torch.ones(10)[2]
+    h = x.hammerblade_ll()
+    _compare(x, h)
+
+def test_llcopy_3():
+    x = torch.ones(3, 4).t()
+    h = x.hammerblade_ll()
+    _compare(x, h)
+
+def test_llcopy_4():
+    x = torch.randn(3, 4).t()
+    h = x.hammerblade_ll()
+    _compare(x, h)
+
+def test_llcopy_5():
+    x = torch.randn(3, 4).t()[2]
+    h = x.hammerblade_ll()
+    _compare(x, h)
+
+def test_normal_copy():
+    x = torch.randn(3, 4).t()[2]
+    h = x.hammerblade()
+    assert not x.is_contiguous()
+    assert h.is_contiguous()

--- a/tools/autograd/templates/python_variable_methods.cpp
+++ b/tools/autograd/templates/python_variable_methods.cpp
@@ -339,6 +339,14 @@ static PyObject * THPVariable_invert(PyObject* self, PyObject* args) {
   END_HANDLE_TH_ERRORS
 }
 
+static PyObject * THPVariable_hammerblade_ll(PyObject* self, PyObject* args, PyObject* kwargs) {
+  HANDLE_TH_ERRORS
+  auto& self_ = reinterpret_cast<THPVariable*>(self)->cdata;
+  torch::utils::hammerblade_lazy_init();
+  return THPVariable_Wrap(self_.llcopy());
+  END_HANDLE_TH_ERRORS
+}
+
 static Tensor dispatch_to(const Tensor & self, Device device, bool non_blocking, bool copy, c10::optional<c10::MemoryFormat> optional_memory_format) {
   AutoNoGIL no_gil;
   // NOTE: this is where we record aten::to in the graph during tracing. However, the behavior of aten::to
@@ -884,6 +892,7 @@ PyMethodDef variable_methods[] = {
   {"cpu", (PyCFunction)(void(*)(void))THPVariable_cpu, METH_VARARGS | METH_KEYWORDS, NULL},
   {"cuda", (PyCFunction)(void(*)(void))THPVariable_cuda, METH_VARARGS | METH_KEYWORDS, NULL},
   {"hammerblade", (PyCFunction)(void(*)(void))THPVariable_hammerblade, METH_VARARGS | METH_KEYWORDS, NULL},
+  {"hammerblade_ll", (PyCFunction)(void(*)(void))THPVariable_hammerblade_ll, METH_VARARGS | METH_KEYWORDS, NULL},
   {"data_ptr", (PyCFunction)THPVariable_data_ptr, METH_NOARGS, NULL},
   {"dim", (PyCFunction)THPVariable_dim, METH_NOARGS, NULL},
 #ifdef BUILD_NAMEDTENSOR


### PR DESCRIPTION
This PR implements `llcopy` and its Python binding `hammerblade_ll`. This operator copies the low level storage space to HB and reconstructs a HB tensor from it. See `hammerblade/torch/tests/test_llcopy.py` for more details.

Note: this operator *does not* prevent double copying issue for now. It will be implemented in the next PR