### PR TITLE
HB Profiler v0

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,37 @@ torch.aten_profiler.unimpl_print()
 
 ### HB Profiling
 
+#### Execution summary
+HammerBlade offloading api also supports profiling the execution time using CUDALite api functions. This can be used as:
+
+```python
+import torch
+import torch.hammerblade.profiler as hbprof
+
+x = torch.rand(2, 3).hammerblade()
+y = torch.rand(2, 3).hammerblade()
+
+# Enables profiling
+hbprof.enable()
+print(x + y)
+print(x * y)
+
+# Prints summary of add and mul kernels
+print(hbprof.summary())
+
+# Disbales profiling: div kernel below won't be profiled
+hbprof.disable()
+print(x / y)
+
+# Clears profiling data structure
+hbprof.clear()
+
+# Enables profiling and only profiles mm kernel
+hbprof.enable()
+print(torch.mm(x, y.t()))
+print(hbprof.summary()
+```
+
 #### HB Kernel Call Logs
 HB emulation can output a file with the list of kernel calls along with associated data in json format. This can be used as:
 

--- a/c10/hammerblade/CMakeLists.txt
+++ b/c10/hammerblade/CMakeLists.txt
@@ -83,6 +83,11 @@ else()
     "-DHB_KERNEL_PATH=${CMAKE_INSTALL_PREFIX}/riscv/kernel.riscv"
     )
 
+  target_compile_definitions(
+    c10_hammerblade PRIVATE
+    "-DCOSIM"
+    )
+
   target_include_directories( c10_hammerblade PUBLIC $ENV{BSG_MANYCORE_DIR} )
 endif()
 

--- a/c10/hammerblade/HammerBladeFunctions.cpp
+++ b/c10/hammerblade/HammerBladeFunctions.cpp
@@ -3,10 +3,10 @@
 
 #include <mutex>
 
+c10::hammerblade::HBProfiler hb_profiler __attribute__ ((visibility ("default")));
+
 namespace c10 {
 namespace hammerblade {
-
-HBProfiler hb_profiler;
 
 namespace {
 static std::once_flag init_flag;

--- a/c10/hammerblade/HammerBladeFunctions.cpp
+++ b/c10/hammerblade/HammerBladeFunctions.cpp
@@ -1,9 +1,12 @@
 #include "HammerBladeFunctions.h"
+#include "HammerBladeProfiler.h"
 
 #include <mutex>
 
 namespace c10 {
 namespace hammerblade {
+
+HBProfiler hb_profiler;
 
 namespace {
 static std::once_flag init_flag;
@@ -72,7 +75,10 @@ void offload_kernel(const char* kernel, std::vector<eva_t> args) {
 
   C10_HB_CHECK(hb_mc_kernel_enqueue(&_hb_device, _hb_grid_dim, _hb_tg_dim, kernel,
                                     args.size(), cuda_argv));
+
+  hb_profiler.kernel_start(kernel);
   C10_HB_CHECK(hb_mc_device_tile_groups_execute(&_hb_device));
+  hb_profiler.kernel_end(kernel);
 
   free(cuda_argv);
 }

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -4,6 +4,8 @@
 //=================================================================
 
 #include <string>
+#include <sstream>
+#include <iomanip>
 #include <c10/hammerblade/HammerBladeException.h>
 #include <bsg_manycore_printing.h>
 #include "HammerBladeProfiler.h"
@@ -22,13 +24,13 @@ struct SummaryCol {
   std::string header;
   std::vector<T> contents;
 
-  int print_width() {
+  int width() {
     return header.length();
   }
 };
 
 template<>
-int SummaryCol<std::string>::print_width() {
+int SummaryCol<std::string>::width() {
   int w = header.length();
 
   for(int i = 0; i < contents.size(); ++i) {
@@ -62,7 +64,7 @@ void HBProfiler::kernel_end(const char* kernel) {
   profile_log[kernel][NUM_CALLS] += 1;
   profile_log[kernel][END_TIME] = elapsed_cycles();
 
-  uint64_t kernel_exec_time = profile_log[kernel][1] - 
+  uint64_t kernel_exec_time = profile_log[kernel][1] -
                                 profile_log[kernel][0];
   profile_log[kernel][CUMMULATIVE] += kernel_exec_time;
   execution_time += kernel_exec_time;
@@ -87,9 +89,26 @@ std::string HBProfiler::summary() {
     num_calls.contents.push_back(k->second[NUM_CALLS]);
   }
 
-  std::string summary = ""; 
+  std::stringstream summary;
 
-  return summary;
+  // Headers
+  summary << std::setw(names.width() + 1) << names.header;
+  summary << std::setw(percents.width() + 1) << percents.header;
+  summary << std::setw(cycles.width() + 1) << cycles.header;
+  summary << std::setw(num_calls.width() + 1) << num_calls.header;
+  summary << std::endl;
+
+  // Underlines
+  summary << std::setw(names.width() + 1) << std::string("=", names.width());
+  summary << std::setw(percents.width() + 1) << std::string("=", percents.width());
+  summary << std::setw(cycles.width() + 1) << std::string("=", cycles.width());
+  summary << std::setw(num_calls.width() + 1) << std::string("=", num_calls.width());
+  summary << std::endl;
+
+  std::string summary_string;
+  summary >> summary_string;
+
+  return summary_string;
 }
 
 }} // namespace c10::hammerblade

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -82,9 +82,12 @@ std::string HBProfiler::summary() {
   num_calls.header = "Number of Calls";
 
   for(auto k = profile_log.begin(); k != profile_log.end(); ++k) {
+    float percentage =
+      execution_time > 0 ? 
+        100.0 * ((float) k->second[CUMMULATIVE] / (float) execution_time) : 
+        0;
     names.contents.push_back(k->first);
-    percents.contents.push_back(
-        100.0 * ((float) k->second[CUMMULATIVE] / (float) execution_time));
+    percents.contents.push_back(percentage);
     cycles.contents.push_back(k->second[CUMMULATIVE]);
     num_calls.contents.push_back(k->second[NUM_CALLS]);
   }

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -93,17 +93,19 @@ std::string HBProfiler::summary() {
   summary << std::endl;
 
   // Headers
-  summary << std::setw(names.width() + 1) << names.header;
-  summary << std::setw(percents.width() + 1) << percents.header;
-  summary << std::setw(cycles.width() + 1) << cycles.header;
-  summary << std::setw(num_calls.width() + 1) << num_calls.header;
+  summary << std::left;
+  summary << std::setw(names.width() + 2) << names.header;
+  summary << std::left << std::setw(percents.width() + 2) << percents.header;
+  summary << std::left << std::setw(cycles.width() + 2) << cycles.header;
+  summary << std::left << std::setw(num_calls.width() + 2) << num_calls.header;
   summary << std::endl;
 
   // Underlines
-  summary << std::setw(names.width() + 1) << std::string("=", names.width());
-  summary << std::setw(percents.width() + 1) << std::string("=", percents.width());
-  summary << std::setw(cycles.width() + 1) << std::string("=", cycles.width());
-  summary << std::setw(num_calls.width() + 1) << std::string("=", num_calls.width());
+  summary << std::right;
+  summary << std::setw(names.width() + 2) << std::setfill('=') << ' ';
+  summary << std::setw(percents.width() + 2) << std::setfill('=') << ' ';
+  summary << std::setw(cycles.width() + 2) << std::setfill('=') << ' ';
+  summary << std::setw(num_calls.width() + 2) << std::setfill('=') << ' ';
   summary << std::endl;
 
   return summary.str();

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -90,6 +90,7 @@ std::string HBProfiler::summary() {
   }
 
   std::stringstream summary;
+  summary << std::endl;
 
   // Headers
   summary << std::setw(names.width() + 1) << names.header;
@@ -105,10 +106,7 @@ std::string HBProfiler::summary() {
   summary << std::setw(num_calls.width() + 1) << std::string("=", num_calls.width());
   summary << std::endl;
 
-  std::string summary_string;
-  summary >> summary_string;
-
-  return summary_string;
+  return summary.str();
 }
 
 }} // namespace c10::hammerblade

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -95,18 +95,29 @@ std::string HBProfiler::summary() {
   // Headers
   summary << std::left;
   summary << std::setw(names.width() + 2) << names.header;
-  summary << std::left << std::setw(percents.width() + 2) << percents.header;
-  summary << std::left << std::setw(cycles.width() + 2) << cycles.header;
-  summary << std::left << std::setw(num_calls.width() + 2) << num_calls.header;
+  summary << std::setw(percents.width() + 2) << percents.header;
+  summary << std::setw(cycles.width() + 2) << cycles.header;
+  summary << std::setw(num_calls.width() + 2) << num_calls.header;
   summary << std::endl;
 
   // Underlines
-  summary << std::right;
-  summary << std::setw(names.width() + 2) << std::setfill('=') << ' ';
-  summary << std::setw(percents.width() + 2) << std::setfill('=') << ' ';
-  summary << std::setw(cycles.width() + 2) << std::setfill('=') << ' ';
-  summary << std::setw(num_calls.width() + 2) << std::setfill('=') << ' ';
-  summary << std::endl;
+  summary << std::right << std::setfill('=');
+  summary << std::setw(names.width() + 2) << ' ';
+  summary << std::setw(percents.width() + 2) << ' ';
+  summary << std::setw(cycles.width() + 2) << ' ';
+  summary << std::setw(num_calls.width() + 2) << ' ';
+  summary << std::setfill(' ') << std::endl;
+
+  // Contents
+  for(int i = 0; i < profile_log.size(); ++i) {
+    summary << std::left;
+    summary << std::setw(names.width() + 2) << names.contents[i];
+    summary << std::setw(percents.width() + 2) << percents.contents[i];
+    summary << std::setw(cycles.width() + 2)
+            << to_string(cycles.contents[i] / 1000000) + 'M';
+    summary << std::setw(num_calls.width() + 2) << num_calls.contents[i];
+    summary << std::endl;
+  }
 
   return summary.str();
 }

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -48,26 +48,30 @@ namespace c10 {
 namespace hammerblade {
 
 void HBProfiler::kernel_start(const char* kernel) {
-  if(profile_log.find(kernel) == profile_log.end()) {
-    profile_log[kernel].fill(0);
-  }
+  if(on) {
+    if(profile_log.find(kernel) == profile_log.end()) {
+      profile_log[kernel].fill(0);
+    }
 
-  profile_log[kernel][START_TIME] = elapsed_cycles();
+    profile_log[kernel][START_TIME] = elapsed_cycles();
+  }
 }
 
 void HBProfiler::kernel_end(const char* kernel) {
-  TORCH_INTERNAL_ASSERT(
-    profile_log.find(kernel) != profile_log.end(),
-    "Can't find the kernel in profiler_log. ",
-    "Please call kernel_start first");
+  if(on) {
+    TORCH_INTERNAL_ASSERT(
+      profile_log.find(kernel) != profile_log.end(),
+      "Can't find the kernel in profiler_log. ",
+      "Please call kernel_start first");
 
-  profile_log[kernel][NUM_CALLS] += 1;
-  profile_log[kernel][END_TIME] = elapsed_cycles();
+    profile_log[kernel][NUM_CALLS] += 1;
+    profile_log[kernel][END_TIME] = elapsed_cycles();
 
-  uint64_t kernel_exec_time = profile_log[kernel][END_TIME] -
-                                profile_log[kernel][START_TIME];
-  profile_log[kernel][CUMMULATIVE] += kernel_exec_time;
-  execution_time += kernel_exec_time;
+    uint64_t kernel_exec_time = profile_log[kernel][END_TIME] -
+                                  profile_log[kernel][START_TIME];
+    profile_log[kernel][CUMMULATIVE] += kernel_exec_time;
+    execution_time += kernel_exec_time;
+  }
 }
 
 std::string HBProfiler::summary() {

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -49,7 +49,7 @@ namespace hammerblade {
 
 void HBProfiler::kernel_start(const char* kernel) {
   if(profile_log.find(kernel) == profile_log.end()) {
-    profile_log[kernel] = {0};
+    profile_log[kernel].fill(0);
   }
 
   profile_log[kernel][START_TIME] = elapsed_cycles();
@@ -64,8 +64,8 @@ void HBProfiler::kernel_end(const char* kernel) {
   profile_log[kernel][NUM_CALLS] += 1;
   profile_log[kernel][END_TIME] = elapsed_cycles();
 
-  uint64_t kernel_exec_time = profile_log[kernel][1] -
-                                profile_log[kernel][0];
+  uint64_t kernel_exec_time = profile_log[kernel][END_TIME] -
+                                profile_log[kernel][START_TIME];
   profile_log[kernel][CUMMULATIVE] += kernel_exec_time;
   execution_time += kernel_exec_time;
 }

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -1,0 +1,39 @@
+//=================================================================
+// HB Profiler
+// 05/03/2020 Bandhav Veluri
+//=================================================================
+
+#include <string>
+#include <c10/hammerblade/HammerBladeException.h>
+#include <bsg_manycore_printing.h>
+#include "HammerBladeProfiler.h"
+
+namespace c10 {
+namespace hammerblade {
+
+void HBProfiler::kernel_start(const char* kernel) {
+  if(profile_log.find(kernel) == profile_log.end()) {
+    profile_log[kernel] = {0};
+  }
+
+  profile_log[kernel][START_TIME] = bsg_time();
+}
+
+void HBProfiler::kernel_end(const char* kernel) {
+  TORCH_INTERNAL_ASSERT(
+    profile_log.find(kernel) != profile_log.end(),
+    "Can't find the kernel in profiler_log. ",
+    "Please call kernel_start first");
+
+  profile_log[kernel][NUM_CALLS] += 1;
+  profile_log[kernel][END_TIME] = bsg_time();
+
+  uint64_t kernel_exec_time = profile_log[kernel][1] - 
+                                profile_log[kernel][0];
+  profile_log[kernel][CUMMULATIVE] += kernel_exec_time;
+  execution_time += kernel_exec_time;
+}
+
+std::string HBProfiler::summary() {}
+
+}} // namespace c10::hammerblade

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -74,6 +74,7 @@ void HBProfiler::kernel_end(const char* kernel) {
   }
 }
 
+__attribute__ ((visibility("default")))
 std::string HBProfiler::summary() {
   SummaryCol<std::string> names;
   SummaryCol<float> percents;

--- a/c10/hammerblade/HammerBladeProfiler.cpp
+++ b/c10/hammerblade/HammerBladeProfiler.cpp
@@ -83,8 +83,8 @@ std::string HBProfiler::summary() {
 
   for(auto k = profile_log.begin(); k != profile_log.end(); ++k) {
     float percentage =
-      execution_time > 0 ? 
-        100.0 * ((float) k->second[CUMMULATIVE] / (float) execution_time) : 
+      execution_time > 0 ?
+        100.0 * ((float) k->second[CUMMULATIVE] / (float) execution_time) :
         0;
     names.contents.push_back(k->first);
     percents.contents.push_back(percentage);
@@ -92,35 +92,45 @@ std::string HBProfiler::summary() {
     num_calls.contents.push_back(k->second[NUM_CALLS]);
   }
 
+  // Underlines
+  std::stringstream underlines;
+  underlines << std::right << std::setfill('-');
+  underlines << std::setw(names.width() + 2) << "" << "+-";
+  underlines << std::setw(percents.width() + 2) << "" << "+-";
+  underlines << std::setw(cycles.width() + 2) << "" << "+-";
+  underlines << std::setw(num_calls.width() + 2) << "" << "+";
+  underlines << std::setfill(' ') << std::endl;
+
   std::stringstream summary;
   summary << std::endl;
 
+  summary << underlines.str();
+
   // Headers
   summary << std::left;
-  summary << std::setw(names.width() + 2) << names.header;
-  summary << std::setw(percents.width() + 2) << percents.header;
-  summary << std::setw(cycles.width() + 2) << cycles.header;
-  summary << std::setw(num_calls.width() + 2) << num_calls.header;
+  summary << std::setw(names.width() + 2) << names.header << "| ";
+  summary << std::setw(percents.width() + 2) << percents.header << "| ";
+  summary << std::setw(cycles.width() + 2) << cycles.header << "| ";
+  summary << std::setw(num_calls.width() + 2) << num_calls.header << "| ";
   summary << std::endl;
 
-  // Underlines
-  summary << std::right << std::setfill('=');
-  summary << std::setw(names.width() + 2) << ' ';
-  summary << std::setw(percents.width() + 2) << ' ';
-  summary << std::setw(cycles.width() + 2) << ' ';
-  summary << std::setw(num_calls.width() + 2) << ' ';
-  summary << std::setfill(' ') << std::endl;
+  summary << underlines.str();
 
   // Contents
   for(int i = 0; i < profile_log.size(); ++i) {
     summary << std::left;
-    summary << std::setw(names.width() + 2) << names.contents[i];
-    summary << std::setw(percents.width() + 2) << percents.contents[i];
+    summary << std::setw(names.width() + 2)
+            << names.contents[i] << "| ";
+    summary << std::setw(percents.width() + 2)
+            << percents.contents[i] << "| ";
     summary << std::setw(cycles.width() + 2)
-            << to_string(cycles.contents[i] / 1000000) + 'M';
-    summary << std::setw(num_calls.width() + 2) << num_calls.contents[i];
+            << to_string(cycles.contents[i] / 1000000) + 'M' << "| ";
+    summary << std::setw(num_calls.width() + 2)
+            << num_calls.contents[i] << "| ";
     summary << std::endl;
   }
+
+  summary << underlines.str();
 
   return summary.str();
 }

--- a/c10/hammerblade/HammerBladeProfiler.h
+++ b/c10/hammerblade/HammerBladeProfiler.h
@@ -3,6 +3,8 @@
 // 05/03/2020 Bandhav Veluri
 //=================================================================
 
+#pragma once
+
 #include <map>
 #include <array>
 
@@ -37,7 +39,7 @@ class HBProfiler {
 
   public:
     HBProfiler() : 
-      on(on),
+      on(false),
       execution_time(0) {}
 
     /**
@@ -50,7 +52,7 @@ class HBProfiler {
     /**
      * Disable profiler
      */
-    void disbale() {
+    void disable() {
       on = false;
     }
 

--- a/c10/hammerblade/HammerBladeProfiler.h
+++ b/c10/hammerblade/HammerBladeProfiler.h
@@ -26,6 +26,9 @@ enum KernelProfileItem {
  * available in cudalite runtime.
  */
 class HBProfiler {
+  // Runtime switch to toggle profiling
+  bool on;
+
   // Cummulative time consumed for executing all kernels
   uint32_t execution_time;
 
@@ -34,7 +37,29 @@ class HBProfiler {
 
   public:
     HBProfiler() : 
+      on(on),
       execution_time(0) {}
+
+    /**
+     * Enable profiler
+     */
+    void enable() {
+      on = true;
+    }
+
+    /**
+     * Disable profiler
+     */
+    void disbale() {
+      on = false;
+    }
+
+    /**
+     * Clear profiler
+     */
+    void clear() {
+      profile_log.clear();
+    }
 
     /**
      * Registers start time of a kernel call.

--- a/c10/hammerblade/HammerBladeProfiler.h
+++ b/c10/hammerblade/HammerBladeProfiler.h
@@ -1,0 +1,47 @@
+//=================================================================
+// HB Profiler
+// 05/03/2020 Bandhav Veluri
+//=================================================================
+
+#include <map>
+#include <string>
+#include <array>
+#include <bsg_manycore_printing.h>
+
+namespace c10 {
+namespace hammerblade {
+
+class HBProfiler {
+  // Cummulative time consumed for executing all kernels
+  uint32_t execution_time;
+
+  // <kernel_name>: {start_time, end_time, cummulative}
+  std::map<std::string, std::array<uint64_t, 3>> profile_log;
+
+  public:
+    HBProfiler() : 
+      execution_time(0) {}
+
+    void kernel_start(const char* kernel) {
+      if(profile_log.find(kernel) == profile_log.end()) {
+        profile_log[kernel] = {0, 0, 0};
+      }
+
+      profile_log[kernel][0] = bsg_time();
+    }
+
+    void kernel_end(const char* kernel) {
+      TORCH_CHECK(
+        profile_log.find(kernel) != profile_log.end(),
+        "Can't find the kernel in the log. Please call kernel_start first");
+
+      profile_log[kernel][1] = bsg_time();
+
+      uint64_t kernel_exec_time = profile_log[kernel][1] - 
+                            profile_log[kernel][0];
+      profile_log[kernel][2] += kernel_exec_time;
+      execution_time += kernel_exec_time;
+    }
+};
+
+}} // namepsace c10::hammerblade

--- a/c10/hammerblade/HammerBladeProfiler.h
+++ b/c10/hammerblade/HammerBladeProfiler.h
@@ -31,9 +31,10 @@ class HBProfiler {
     }
 
     void kernel_end(const char* kernel) {
-      TORCH_CHECK(
+      TORCH_INTERNAL_ASSERT(
         profile_log.find(kernel) != profile_log.end(),
-        "Can't find the kernel in the log. Please call kernel_start first");
+        "Can't find the kernel in profiler_log. ",
+        "Please call kernel_start first");
 
       profile_log[kernel][1] = bsg_time();
 

--- a/c10/hammerblade/emul/bsg_manycore_printing.h
+++ b/c10/hammerblade/emul/bsg_manycore_printing.h
@@ -1,0 +1,113 @@
+// Copyright (c) 2019, University of Washington All rights reserved.
+// 
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+// 
+// Redistributions of source code must retain the above copyright notice, this list
+// of conditions and the following disclaimer.
+// 
+// Redistributions in binary form must reproduce the above copyright notice, this
+// list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+// 
+// Neither the name of the copyright holder nor the names of its contributors may
+// be used to endorse or promote products derived from this software without
+// specific prior written permission.
+// 
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+// ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+// WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+// DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+// ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+// (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+// LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+// ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+// SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#ifndef _BSG_MANYCORE_PRINTING_H
+#define _BSG_MANYCORE_PRINTING_H
+#include <bsg_manycore_features.h>
+
+#ifdef __cplusplus
+#include <cstdint>
+#include <cstddef>
+#else
+#include <stdint.h>
+#include <stddef.h>
+#endif
+
+#include <sys/time.h>
+#if defined(__cplusplus)
+extern "C" {
+#endif // #if defined(__cplusplus)
+
+        /* #if defined(COSIM) */
+        /* #define BSG_PRINT_PREFIX_DEBUG "DEBUG @(%llu/%llu):   " */
+        /* #else // !defined(COSIM) */
+        /* #define BSG_PRINT_PREFIX_DEBUG "DEBUG @(%llu):   " */
+        /* #endif */
+
+#define BSG_PRINT_PREFIX_DEBUG "DEBUG"
+#define BSG_PRINT_PREFIX_ERROR "ERROR:   "
+#define BSG_PRINT_PREFIX_WARN  "WARNING: "
+#define BSG_PRINT_PREFIX_INFO  "INFO:    "
+
+#define BSG_PRINT_STREAM_DEBUG stderr
+#define BSG_PRINT_STREAM_ERROR stderr
+#define BSG_PRINT_STREAM_WARN  stderr
+#define BSG_PRINT_STREAM_INFO  stderr
+
+#ifdef COSIM
+        extern void sv_bsg_time(uint64_t*);
+#endif
+        uint64_t bsg_time() {
+          return 0;
+        }
+
+        static inline uint64_t bsg_utc(){
+                struct timeval tv;
+                gettimeofday(&tv, NULL);
+
+                uint64_t ms =
+                        (uint64_t)(tv.tv_sec) * 1000 +
+                        (uint64_t)(tv.tv_usec) / 1000;
+
+                return ms;
+        }
+
+        __attribute__((format(printf, 2, 3)))
+        int bsg_pr_prefix(const char *prefix, const char *fmt, ...);
+
+        /* #if defined(DEBUG) && defined(COSIM) */
+        /* #define bsg_pr_dbg(fmt, ...)                    \ */
+        /*         bsg_pr_prefix(BSG_PRINT_PREFIX_DEBUG, fmt, bsg_time(), bsg_utc(), ##__VA_ARGS__) */
+        /* #elif defined(DEBUG) */
+        /* #define bsg_pr_dbg(fmt, ...)                    \ */
+        /*         bsg_pr_prefix(BSG_PRINT_PREFIX_DEBUG, fmt, bsg_utc(), ##__VA_ARGS__) */
+        /* #else  */
+        /* #define bsg_pr_dbg(...) */
+        /* #endif */
+
+#if defined(DEBUG)
+#define bsg_pr_dbg(fmt, ...)                                            \
+        bsg_pr_prefix(BSG_PRINT_PREFIX_DEBUG, fmt, ##__VA_ARGS__)
+#else
+#define bsg_pr_dbg(...)
+#endif
+
+#define bsg_pr_err(fmt, ...)                                            \
+        bsg_pr_prefix(BSG_PRINT_PREFIX_ERROR, fmt, ##__VA_ARGS__)
+
+#define bsg_pr_warn(fmt, ...)                                           \
+        bsg_pr_prefix(BSG_PRINT_PREFIX_WARN, fmt, ##__VA_ARGS__)
+
+#define bsg_pr_info(fmt, ...)                                           \
+        bsg_pr_prefix(BSG_PRINT_PREFIX_INFO, fmt, ##__VA_ARGS__)
+
+
+#if defined(__cplusplus)
+}
+#endif // #if defined(__cplusplus)
+
+#endif

--- a/hammerblade/torch/hb_pytorch_link.ld
+++ b/hammerblade/torch/hb_pytorch_link.ld
@@ -106,18 +106,10 @@ SECTIONS
   } >DMEM_VMA 
 
 
-  .eh_frame.dmem : 
-  AT(LOADADDR(.tbss.dmem) + SIZEOF(.tbss.dmem)) 
-  { 
-    *(.eh_frame) 
-    *(.eh_frame*) 
-  } >DMEM_VMA 
-
-  
   /* striped data */
   /* RISC-V 32 has a 4 byte word size */
   .striped.data.dmem ALIGN(bsg_group_size * 4) : 
-  AT(LOADADDR(.eh_frame.dmem) + SIZEOF(.eh_frame.dmem)) 
+  AT(LOADADDR(.tbss.dmem) + SIZEOF(.tbss.dmem)) 
   {
     _bsg_striped_data_start = . ;
     *(.striped.data)
@@ -177,6 +169,13 @@ SECTIONS
     *(.dram)
     . = ALIGN(4);
   } >DRAM_D_VMA 
+
+
+  /DISCARD/ :
+  {
+    *(.eh_frame)
+    *(.eh_frame*)
+  }
 
   _bsg_dram_d_end_addr = . ;
   _bsg_dram_end_addr = . ;

--- a/torch/csrc/hammerblade/Module.cpp
+++ b/torch/csrc/hammerblade/Module.cpp
@@ -9,6 +9,7 @@
 #include <ATen/hammerblade/HammerBladeContext.h>
 #include <ATen/HammerBladeGenerator.h>
 #include <c10/hammerblade/HammerBladeFunctions.h>
+#include <c10/hammerblade/HammerBladeProfiler.h>
 // #include <c10/hammerblade/HammerBladeCachingAllocator.h>
 
 #include <torch/csrc/hammerblade/THBP.h>
@@ -19,6 +20,8 @@
 #include <torch/csrc/hammerblade/python_comm.h>
 #include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/Generator.h>
+
+extern HBProfiler hb_profiler;
 
 #ifdef HB_ENABLE_KERNEL_LOG
 #include <c10/hammerblade/emul/kernel_logger.h>
@@ -49,6 +52,38 @@ PyObject * THBPModule_set_run_yet_variable_to_false_wrap(PyObject *self, PyObjec
   torch::utils::hammerblade_set_run_yet_variable_to_false();
   Py_RETURN_NONE;
   END_HANDLE_TH_ERRORS
+}
+
+PyObject * THBPModule_enable_profiler(PyObject *self, PyObject *noargs)
+{
+  HANDLE_TH_ERRORS
+  hb_profiler.enable();
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS;
+}
+
+PyObject * THBPModule_disable_profiler(PyObject *self, PyObject *noargs)
+{
+  HANDLE_TH_ERRORS
+  hb_profiler.disable();
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS;
+}
+
+PyObject * THBPModule_summary_profiler(PyObject *self, PyObject *noargs)
+{
+  HANDLE_TH_ERRORS
+  std::string log = hb_profiler.summary();
+  return PyUnicode_FromString(log.c_str());
+  END_HANDLE_TH_ERRORS;
+}
+
+PyObject * THBPModule_clear_profiler(PyObject *self, PyObject *noargs)
+{
+  HANDLE_TH_ERRORS
+  hb_profiler.clear();
+  Py_RETURN_NONE;
+  END_HANDLE_TH_ERRORS;
 }
 
 #ifdef HB_ENABLE_KERNEL_LOG
@@ -142,6 +177,14 @@ static struct PyMethodDef _THBPModule_methods[] = {
   {"_hammerblade_getDevice",   (PyCFunction)THBPModule_getDevice_wrap,   METH_NOARGS,  nullptr},
   {"_hammerblade_set_run_yet_variable_to_false",
     (PyCFunction)THBPModule_set_run_yet_variable_to_false_wrap, METH_NOARGS, nullptr},
+  {"_hammerblade_enable_profiler",
+    (PyCFunction)THBPModule_enable_profiler, METH_NOARGS, nullptr},
+  {"_hammerblade_disable_profiler",
+    (PyCFunction)THBPModule_disable_profiler, METH_NOARGS, nullptr},
+  {"_hammerblade_summary_profiler",
+    (PyCFunction)THBPModule_summary_profiler, METH_NOARGS, nullptr},
+  {"_hammerblade_clear_profiler",
+    (PyCFunction)THBPModule_clear_profiler, METH_NOARGS, nullptr},
 #ifdef HB_ENABLE_KERNEL_LOG
   {"_hammerblade_enable_kernel_call_logger",
     (PyCFunction)THBPModule_enable_kernel_call_logger, METH_NOARGS, nullptr},

--- a/torch/csrc/hammerblade/Module.cpp
+++ b/torch/csrc/hammerblade/Module.cpp
@@ -21,7 +21,7 @@
 #include <torch/csrc/autograd/generated/variable_factories.h>
 #include <torch/csrc/Generator.h>
 
-extern HBProfiler hb_profiler;
+extern c10::hammerblade::HBProfiler hb_profiler;
 
 #ifdef HB_ENABLE_KERNEL_LOG
 #include <c10/hammerblade/emul/kernel_logger.h>

--- a/torch/hammerblade/profiler.py
+++ b/torch/hammerblade/profiler.py
@@ -1,0 +1,13 @@
+import torch
+
+def enable():
+    torch._C._hammerblade_enable_profiler()
+
+def disable():
+    torch._C._hammerblade_disable_profiler()
+
+def summary():
+    return torch._C._hammerblade_summary_profiler()
+
+def clear():
+    torch._C._hammerblade_clear_profiler()


### PR DESCRIPTION
Implements HB profiler and python bindings to profile individual kernels from python.

A tiny program like this:
```python
  1 import torch
  2 import torch.hammerblade.profiler as hbprof
  3
  4 x = torch.rand(2, 3).hammerblade()
  5 y = torch.rand(2, 3).hammerblade()
  6
  7 hbprof.enable()
  8 print(x + y)
  9 print(torch.mm(x, y.t()))
 10 print(hbprof.summary())
```

Outputs this on cosim:
```
tensor([[1.0914, 0.4428, 0.4938],
        [1.0323, 1.3454, 0.2439]], device='hammerblade')
tensor([[0.2552, 0.4545],
        [0.2490, 0.5537]], device='hammerblade')

-----------------+-------------+------------------+------------------+
Kernel Name      | HB Total %  | HB Total Cycles  | Number of Calls  |
-----------------+-------------+------------------+------------------+
tensorlib_add    | 24.4588     | 7M               | 1                |
tensorlib_addmm  | 50.3176     | 15M              | 1                |
tensorlib_fill   | 25.2236     | 7M               | 1                |
-----------------+-------------+------------------+------------------+

BSG REGRESSION TEST PASSED
BSG COSIM PASS: Test passed!
```
Also works on emulation, but everything except number of calls is 0. For complete interface, see https://github.com/cornell-brg/hb-pytorch/tree/cosim_profiler#execution-summary.