### PR TITLE
kz73_addmm_unroll

### DIFF
--- a/hammerblade/torch/kernel/kernel_addmm.cpp
+++ b/hammerblade/torch/kernel/kernel_addmm.cpp
@@ -5,9 +5,60 @@
 
 #include <kernel_common.hpp>
 #include <cmath>
-#define BLOCK_DIM 10 // sqrt(4KB/4 byte/4 data matrix) = 15 max
+#define BLOCK_DIM 8 // sqrt(4KB/4 byte/4 data matrix) = 15 max
 
 extern "C" {
+
+  __attribute__ ((noinline)) void compute(
+          float* dest,
+          float* sp_mat1,
+          float* sp_mat2,
+          float alpha,
+          int dim_y,
+          int dim_x,
+          int mid_dim) {
+    for (int i = 0; i < dim_y; i++) {
+        int dest_row_offset = i * dim_x;
+        int mat1_row_offset = i * mid_dim;
+        for (int j = 0; j < dim_x; j++) {
+            for (int k = 0; k < mid_dim; k += 2) {
+                int mat1_idx = mat1_row_offset + k;
+                int mat2_idx = k * dim_x + j;
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx] * sp_mat2[mat2_idx]; 
+                if (k + 1 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 1] * sp_mat2[mat2_idx + dim_x];
+               // if (k + 2 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 2] * sp_mat2[mat2_idx + 2 * dim_x]; 
+               // if (k + 3 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 3] * sp_mat2[mat2_idx + 3 * dim_x];
+               // if (k + 4 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 4] * sp_mat2[mat2_idx + 4 * dim_x]; 
+               // if (k + 5 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 5] * sp_mat2[mat2_idx + 5 * dim_x]; 
+               // if (k + 6 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 6] * sp_mat2[mat2_idx + 6 * dim_x]; 
+               // if (k + 7 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 7] * sp_mat2[mat2_idx + 7 * dim_x]; 
+            }
+        }
+    }
+}
+
+  __attribute__ ((noinline))  void dram_to_sp(
+          float* dest,
+          float coeff,
+          HBTensor<float> src,
+          int dim_y,
+          int dim_x,
+          int r_idx,
+          int c_idx) {
+    for (int i = 0; i < dim_y; i++) {
+        int row_offset = i * dim_x;
+        for (int j = 0; j < dim_x; j += 2) {
+            dest[row_offset + j] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j);
+            if (j + 1 < dim_x) dest[row_offset + j + 1] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 1);
+           // if (j + 2 < dim_x) dest[row_offset + j + 2] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 2);
+           // if (j + 3 < dim_x) dest[row_offset + j + 3] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 3);
+           // if (j + 4 < dim_x) dest[row_offset + j + 4] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 4);
+           // if (j + 5 < dim_x) dest[row_offset + j + 5] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 5);
+           // if (j + 6 < dim_x) dest[row_offset + j + 6] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 6);
+           // if (j + 7 < dim_x) dest[row_offset + j + 7] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 7);
+        }
+    }
+}
 
   __attribute__ ((noinline))  int tensorlib_addmm(
           hb_tensor_t* _result,
@@ -28,6 +79,7 @@ extern "C" {
 
         // Start profiling
         bsg_cuda_print_stat_kernel_start();
+
 
         // v2: single tile, use blocking
         int r1 = mat1.dim(0);
@@ -55,21 +107,25 @@ extern "C" {
                 int res_dim_y = rr == m1_num_blk_per_row - 1 ? m1_last_blk_dim_y : BLOCK_DIM;
                 int res_dim_x = rc == m2_num_blk_per_col - 1 ? m2_last_blk_dim_x : BLOCK_DIM;
 
-                // initialize scratchpad result
-                float sp_result[res_dim_y][res_dim_x];
-                for (int i = 0; i < res_dim_y; i++) {
-                    for (int j = 0; j < res_dim_x; j++) {
-                        sp_result[i][j] = 0.0f;
-                    }
-                }
+                // initialize scratchpad result (load beta * self into result)
 
-                // load self into scratchpad
-                float sp_self[res_dim_y][res_dim_x];
+                // unrolled version
+                float sp_result[res_dim_y * res_dim_x];
+                dram_to_sp(sp_result, beta, self, res_dim_y, res_dim_x, rr, rc);
+                // end: unrolled version
+
+/*
+                // original non-unrolled version
+                float sp_result[res_dim_y][res_dim_x];
+
                 for (int i = 0; i < res_dim_y; i++) {
                     for (int j = 0; j < res_dim_x; j++) {
-                        sp_self[i][j] = self(rr * BLOCK_DIM + i, rc * BLOCK_DIM + j);
+                        sp_result[i][j] = beta * self(rr * BLOCK_DIM + i, rc * BLOCK_DIM + j);
                     }
                 }
+                // end: original non-unrolled version
+*/
+
 
                 // process mat1 and mat2 for this result block
                 // only care about blocks of mat1 in row rr
@@ -80,10 +136,22 @@ extern "C" {
                     // calculate current block dimensions
                     int mid_dim = mat1x == m1_num_blk_per_col - 1 ? m1_last_blk_dim_x : BLOCK_DIM;
 
+
                     // load mat1 and mat2 into scratchpad
+
+                    // unrolled version
+                    float sp_mat1[res_dim_y * mid_dim];
+                    float sp_mat2[mid_dim * res_dim_x];
+                    dram_to_sp(sp_mat1, 1.0f, mat1, res_dim_y, mid_dim, rr, mat1x);
+                    dram_to_sp(sp_mat2, 1.0f, mat2, mid_dim, res_dim_x, mat2y, rc);
+                    compute(sp_result, sp_mat1, sp_mat2, alpha, res_dim_y, res_dim_x, mid_dim);
+                    // end: unrolled version
+
+
+/*
+                    // original non-unrolled version
                     float sp_mat1[res_dim_y][mid_dim];
                     float sp_mat2[mid_dim][res_dim_x];
-
                     for (int i = 0; i < res_dim_y; i++) {
                         for (int j = 0; j < mid_dim; j++) {
                             sp_mat1[i][j] = mat1(rr * BLOCK_DIM + i, mat1x * BLOCK_DIM + j);
@@ -100,24 +168,26 @@ extern "C" {
                     for (int i = 0; i < res_dim_y; i++) {
                         for (int j = 0; j < res_dim_x; j++) {
                             for (int k = 0; k < mid_dim; k++) {
-                                sp_result[i][j] += sp_mat1[i][k] * sp_mat2[k][j]; 
+                                sp_result[i][j] += alpha * sp_mat1[i][k] * sp_mat2[k][j]; 
                             }
                         }
                     }
+                    // end: non-unrolled version
+*/
+
                 }
 
-                // result = beta * self + alpha * (mat1 X mat2)
-                for (int i = 0; i < res_dim_y; i++) {
-                    for (int j = 0; j < res_dim_x; j++) {
-                        sp_result[i][j] *= alpha;
-                        sp_result[i][j] += beta * sp_self[i][j];
-                    }
-                }
 
                 // copy this block back into DRAM
                 for (int i = 0; i < res_dim_y; i++) {
                     for (int j = 0; j < res_dim_x; j++) {
-                        result(rr * BLOCK_DIM + i, rc * BLOCK_DIM + j) = sp_result[i][j];
+                        // unrolled version
+                        result(rr * BLOCK_DIM + i, rc * BLOCK_DIM + j) = sp_result[i * res_dim_x + j];
+                        // end: unrolled version
+
+                        // original non-unrolled version
+                        //result(rr * BLOCK_DIM + i, rc * BLOCK_DIM + j) = sp_result[i][j];
+                        // end: original non-unrolled version
                     }
                 }
             }

--- a/hammerblade/torch/kernel/kernel_addmm.cpp
+++ b/hammerblade/torch/kernel/kernel_addmm.cpp
@@ -8,10 +8,8 @@
 
 extern "C" {
 
-    // TODO:
-    // have two versions of compute and dram_to_sp
-    // one without if checks and one with
-
+  // Handles the common case:
+  // Assume dim_y and dim_x are both exactly BLOCK_SIZE
   void compute_simple(
           float* dest,
           float* sp_mat1,
@@ -40,6 +38,8 @@ extern "C" {
     }
 }
 
+  // Handles the common case:
+  // Assume dim_y and dim_x are both exactly BLOCK_SIZE
   void dram_to_sp_simple(
           float* dest,
           float coeff,
@@ -63,6 +63,8 @@ extern "C" {
     }
 }
 
+  // Handles the general case:
+  // dim_y and dim_x can be less than BLOCK_SIZE
   void compute(
           float* dest,
           float* sp_mat1,
@@ -91,6 +93,9 @@ extern "C" {
     }
 }
 
+
+  // Handles the general case:
+  // dim_y and dim_x can be less than BLOCK_SIZE
   void dram_to_sp(
           float* dest,
           float coeff,
@@ -166,9 +171,9 @@ extern "C" {
 
                 // unrolled version
                 float sp_result[res_dim_y * res_dim_x];
-                if (partial_block) {
+                if (partial_block) { // general case
                     dram_to_sp(sp_result, beta, self, res_dim_y, res_dim_x, rr, rc);
-                } else {
+                } else { // common case: res_dim_y == res_dim_x == BLOCK_SIZE
                     dram_to_sp_simple(sp_result, beta, self, res_dim_y, res_dim_x, rr, rc);
                 }
                 // end: unrolled version
@@ -199,11 +204,11 @@ extern "C" {
                     // unrolled version
                     float sp_mat1[res_dim_y * mid_dim];
                     float sp_mat2[mid_dim * res_dim_x];
-                    if (partial_block) {
+                    if (partial_block) { // general case
                         dram_to_sp(sp_mat1, 1.0f, mat1, res_dim_y, mid_dim, rr, mat1x);
                         dram_to_sp(sp_mat2, 1.0f, mat2, mid_dim, res_dim_x, mat2y, rc);
                         compute(sp_result, sp_mat1, sp_mat2, alpha, res_dim_y, res_dim_x, mid_dim);
-                    } else {
+                    } else { // common case: res_dim_y == res_dim_x == BLOCK_SIZE
                         dram_to_sp_simple(sp_mat1, 1.0f, mat1, res_dim_y, mid_dim, rr, mat1x);
                         dram_to_sp_simple(sp_mat2, 1.0f, mat2, mid_dim, res_dim_x, mat2y, rc);
                         compute_simple(sp_result, sp_mat1, sp_mat2, alpha, res_dim_y, res_dim_x, mid_dim);

--- a/hammerblade/torch/kernel/kernel_addmm.cpp
+++ b/hammerblade/torch/kernel/kernel_addmm.cpp
@@ -4,12 +4,15 @@
 //====================================================================
 
 #include <kernel_common.hpp>
-#include <cmath>
 #define BLOCK_DIM 8 // sqrt(4KB/4 byte/4 data matrix) = 15 max
 
 extern "C" {
 
-  __attribute__ ((noinline)) void compute(
+    // TODO:
+    // have two versions of compute and dram_to_sp
+    // one without if checks and one with
+
+  void compute_simple(
           float* dest,
           float* sp_mat1,
           float* sp_mat2,
@@ -21,23 +24,23 @@ extern "C" {
         int dest_row_offset = i * dim_x;
         int mat1_row_offset = i * mid_dim;
         for (int j = 0; j < dim_x; j++) {
-            for (int k = 0; k < mid_dim; k += 2) {
+            for (int k = 0; k < mid_dim; k += 8) {
                 int mat1_idx = mat1_row_offset + k;
                 int mat2_idx = k * dim_x + j;
                 dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx] * sp_mat2[mat2_idx]; 
-                if (k + 1 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 1] * sp_mat2[mat2_idx + dim_x];
-               // if (k + 2 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 2] * sp_mat2[mat2_idx + 2 * dim_x]; 
-               // if (k + 3 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 3] * sp_mat2[mat2_idx + 3 * dim_x];
-               // if (k + 4 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 4] * sp_mat2[mat2_idx + 4 * dim_x]; 
-               // if (k + 5 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 5] * sp_mat2[mat2_idx + 5 * dim_x]; 
-               // if (k + 6 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 6] * sp_mat2[mat2_idx + 6 * dim_x]; 
-               // if (k + 7 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 7] * sp_mat2[mat2_idx + 7 * dim_x]; 
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 1] * sp_mat2[mat2_idx + dim_x];
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 2] * sp_mat2[mat2_idx + 2 * dim_x]; 
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 3] * sp_mat2[mat2_idx + 3 * dim_x];
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 4] * sp_mat2[mat2_idx + 4 * dim_x]; 
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 5] * sp_mat2[mat2_idx + 5 * dim_x]; 
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 6] * sp_mat2[mat2_idx + 6 * dim_x]; 
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 7] * sp_mat2[mat2_idx + 7 * dim_x]; 
             }
         }
     }
 }
 
-  __attribute__ ((noinline))  void dram_to_sp(
+  void dram_to_sp_simple(
           float* dest,
           float coeff,
           HBTensor<float> src,
@@ -47,15 +50,66 @@ extern "C" {
           int c_idx) {
     for (int i = 0; i < dim_y; i++) {
         int row_offset = i * dim_x;
-        for (int j = 0; j < dim_x; j += 2) {
+        for (int j = 0; j < dim_x; j += 8) {
+            dest[row_offset + j] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j);
+            dest[row_offset + j + 1] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 1);
+            dest[row_offset + j + 2] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 2);
+            dest[row_offset + j + 3] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 3);
+            dest[row_offset + j + 4] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 4);
+            dest[row_offset + j + 5] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 5);
+            dest[row_offset + j + 6] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 6);
+            dest[row_offset + j + 7] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 7);
+        }
+    }
+}
+
+  void compute(
+          float* dest,
+          float* sp_mat1,
+          float* sp_mat2,
+          float alpha,
+          int dim_y,
+          int dim_x,
+          int mid_dim) {
+    for (int i = 0; i < dim_y; i++) {
+        int dest_row_offset = i * dim_x;
+        int mat1_row_offset = i * mid_dim;
+        for (int j = 0; j < dim_x; j++) {
+            for (int k = 0; k < mid_dim; k += 8) {
+                int mat1_idx = mat1_row_offset + k;
+                int mat2_idx = k * dim_x + j;
+                dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx] * sp_mat2[mat2_idx]; 
+                if (k + 1 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 1] * sp_mat2[mat2_idx + dim_x];
+                if (k + 2 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 2] * sp_mat2[mat2_idx + 2 * dim_x]; 
+                if (k + 3 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 3] * sp_mat2[mat2_idx + 3 * dim_x];
+                if (k + 4 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 4] * sp_mat2[mat2_idx + 4 * dim_x]; 
+                if (k + 5 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 5] * sp_mat2[mat2_idx + 5 * dim_x]; 
+                if (k + 6 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 6] * sp_mat2[mat2_idx + 6 * dim_x]; 
+                if (k + 7 < mid_dim) dest[dest_row_offset + j] += alpha * sp_mat1[mat1_idx + 7] * sp_mat2[mat2_idx + 7 * dim_x]; 
+            }
+        }
+    }
+}
+
+  void dram_to_sp(
+          float* dest,
+          float coeff,
+          HBTensor<float> src,
+          int dim_y,
+          int dim_x,
+          int r_idx,
+          int c_idx) {
+    for (int i = 0; i < dim_y; i++) {
+        int row_offset = i * dim_x;
+        for (int j = 0; j < dim_x; j += 8) {
             dest[row_offset + j] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j);
             if (j + 1 < dim_x) dest[row_offset + j + 1] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 1);
-           // if (j + 2 < dim_x) dest[row_offset + j + 2] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 2);
-           // if (j + 3 < dim_x) dest[row_offset + j + 3] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 3);
-           // if (j + 4 < dim_x) dest[row_offset + j + 4] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 4);
-           // if (j + 5 < dim_x) dest[row_offset + j + 5] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 5);
-           // if (j + 6 < dim_x) dest[row_offset + j + 6] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 6);
-           // if (j + 7 < dim_x) dest[row_offset + j + 7] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 7);
+            if (j + 2 < dim_x) dest[row_offset + j + 2] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 2);
+            if (j + 3 < dim_x) dest[row_offset + j + 3] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 3);
+            if (j + 4 < dim_x) dest[row_offset + j + 4] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 4);
+            if (j + 5 < dim_x) dest[row_offset + j + 5] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 5);
+            if (j + 6 < dim_x) dest[row_offset + j + 6] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 6);
+            if (j + 7 < dim_x) dest[row_offset + j + 7] = coeff * src(r_idx * BLOCK_DIM + i, c_idx * BLOCK_DIM + j + 7);
         }
     }
 }
@@ -106,12 +160,17 @@ extern "C" {
                 // calculate current result block dimensions
                 int res_dim_y = rr == m1_num_blk_per_row - 1 ? m1_last_blk_dim_y : BLOCK_DIM;
                 int res_dim_x = rc == m2_num_blk_per_col - 1 ? m2_last_blk_dim_x : BLOCK_DIM;
+                int partial_block = (res_dim_y != BLOCK_DIM) || (res_dim_x != BLOCK_DIM);
 
                 // initialize scratchpad result (load beta * self into result)
 
                 // unrolled version
                 float sp_result[res_dim_y * res_dim_x];
-                dram_to_sp(sp_result, beta, self, res_dim_y, res_dim_x, rr, rc);
+                if (partial_block) {
+                    dram_to_sp(sp_result, beta, self, res_dim_y, res_dim_x, rr, rc);
+                } else {
+                    dram_to_sp_simple(sp_result, beta, self, res_dim_y, res_dim_x, rr, rc);
+                }
                 // end: unrolled version
 
 /*
@@ -131,20 +190,24 @@ extern "C" {
                 // only care about blocks of mat1 in row rr
                 // and blocks of mat2 in col rc
                 for (int mat1x = 0, mat2y = 0; mat1x < m1_num_blk_per_col && mat2y < m2_num_blk_per_row; mat1x++, mat2y++) {
-                    hb_assert(mat1x == mat2y);
-
                     // calculate current block dimensions
                     int mid_dim = mat1x == m1_num_blk_per_col - 1 ? m1_last_blk_dim_x : BLOCK_DIM;
-
+                    partial_block = partial_block || (mid_dim != BLOCK_DIM);
 
                     // load mat1 and mat2 into scratchpad
 
                     // unrolled version
                     float sp_mat1[res_dim_y * mid_dim];
                     float sp_mat2[mid_dim * res_dim_x];
-                    dram_to_sp(sp_mat1, 1.0f, mat1, res_dim_y, mid_dim, rr, mat1x);
-                    dram_to_sp(sp_mat2, 1.0f, mat2, mid_dim, res_dim_x, mat2y, rc);
-                    compute(sp_result, sp_mat1, sp_mat2, alpha, res_dim_y, res_dim_x, mid_dim);
+                    if (partial_block) {
+                        dram_to_sp(sp_mat1, 1.0f, mat1, res_dim_y, mid_dim, rr, mat1x);
+                        dram_to_sp(sp_mat2, 1.0f, mat2, mid_dim, res_dim_x, mat2y, rc);
+                        compute(sp_result, sp_mat1, sp_mat2, alpha, res_dim_y, res_dim_x, mid_dim);
+                    } else {
+                        dram_to_sp_simple(sp_mat1, 1.0f, mat1, res_dim_y, mid_dim, rr, mat1x);
+                        dram_to_sp_simple(sp_mat2, 1.0f, mat2, mid_dim, res_dim_x, mat2y, rc);
+                        compute_simple(sp_result, sp_mat1, sp_mat2, alpha, res_dim_y, res_dim_x, mid_dim);
+                    }
                     // end: unrolled version
 
 

--- a/hammerblade/torch/pytest_runner.py
+++ b/hammerblade/torch/pytest_runner.py
@@ -48,5 +48,4 @@ print(" starting pytest ...")
 print()
 
 # invoke pytest main loop
-#exit(pytest.main(pytest_argv + targets + ['-k torch_addmm_perf']))
-exit(pytest.main(pytest_argv + targets + ['-k torch_addmm_perf']))
+exit(pytest.main(pytest_argv + targets))

--- a/hammerblade/torch/pytest_runner.py
+++ b/hammerblade/torch/pytest_runner.py
@@ -6,7 +6,7 @@ Lin Cheng
 """
 
 # pytest commandline options
-pytest_argv = ["-v"]
+pytest_argv = ["-vs"]
 
 # This is a work around of the bug in which sys.argv is not set
 # when running as embededd script
@@ -48,4 +48,5 @@ print(" starting pytest ...")
 print()
 
 # invoke pytest main loop
-exit(pytest.main(pytest_argv + targets))
+#exit(pytest.main(pytest_argv + targets + ['-k torch_addmm_perf']))
+exit(pytest.main(pytest_argv + targets + ['-k torch_addmm_perf']))

--- a/hammerblade/torch/pytest_runner.py
+++ b/hammerblade/torch/pytest_runner.py
@@ -6,7 +6,7 @@ Lin Cheng
 """
 
 # pytest commandline options
-pytest_argv = ["-vs"]
+pytest_argv = ["-v"]
 
 # This is a work around of the bug in which sys.argv is not set
 # when running as embededd script

--- a/hammerblade/torch/tests/test_addmm.py
+++ b/hammerblade/torch/tests/test_addmm.py
@@ -16,8 +16,20 @@ def _test_torch_addmm(M, mat1, mat2, rel_tol=1e-05, abs_tol=1e-08):
     assert out_h.device == torch.device("hammerblade")
     assert torch.allclose(out_h.cpu(), out, rtol=rel_tol, atol=abs_tol)
 
-def test_torch_addmm_basic():
+def test_torch_addmm_perf():
+    _test_torch_addmm(torch.randn(16, 16), torch.randn(16, 16), torch.randn(16, 16), 1e-03, 1e-06)
+
+def test_torch_addmm_tt():
+    M = torch.tensor([[1., 2., 3.], [4., 5., 6.]])
+    mat1 = torch.tensor([[7., 8., 9.], [10., 11., 12.]])
+    mat2 = torch.tensor([[13., 14., 15.], [16., 17., 18.], [19., 20., 21.]])
+    _test_torch_addmm(M, mat1, mat2)
+
+def test_torch_addmm_basic1():
     _test_torch_addmm(torch.ones(2, 3), torch.ones(2, 3), torch.ones(3, 3))
+
+def test_torch_addmm_basic2():
+    _test_torch_addmm(torch.ones(16, 16), torch.randn(16, 16), torch.ones(16, 16))
 
 # 1x1 matrices
 def test_torch_addmm_1x1():


### PR DESCRIPTION
Performance improvements for the addmm kernel. Includes:
- `BLOCK_SIZE` is now a factor of 2 (8)
- refactor `dram_to_sp` and `compute` to make code more readable
    - also allows experimenting with different unroll factors
- separate common case vs general case when computing a block to minimize number of branch instructions
    - common case: result block size is same as `BLOCK_SIZE` (8)
    - general case: result block size can be smaller than `BLOCK_SIZE` -> partial blocks require additional checks when loading from DRAM and computing
- unroll by 8 in innerloop of both `dram_to_sp` and `compute`
    - this seems like the best unroll factor based on preliminary testing (may need more investigation though!)

Future TODOs:
- investigate best unroll factor
- more microbenchmarking on loading data from DRAM to scratchpad