### PR TITLE
DMA tensor copy

### DIFF
--- a/aten/src/ATen/native/hammerblade/Copy.cpp
+++ b/aten/src/ATen/native/hammerblade/Copy.cpp
@@ -37,7 +37,7 @@ static void copy_cpu_to_hb(TensorIterator& iter, bool non_blocking) {
   void* src = iter.data_ptr(1);
   // hb_mc_device_memcpy takes void* as dst and src
   uint32_t nbytes = iter.numel() * iter.element_size(0);
-  c10::hammerblade::memcpy_host_to_device(dst, src, nbytes);
+  c10::hammerblade::DMA_host_to_device(dst, src, nbytes);
 }
 
 static void copy_hb_to_cpu(TensorIterator& iter, bool non_blocking) {
@@ -45,7 +45,7 @@ static void copy_hb_to_cpu(TensorIterator& iter, bool non_blocking) {
   void* src = iter.data_ptr(1);
   // hb_mc_device_memcpy takes void* as dst and src
   uint32_t nbytes = iter.numel() * iter.element_size(0);
-  c10::hammerblade::memcpy_device_to_host(dst, src, nbytes);
+  c10::hammerblade::DMA_device_to_host(dst, src, nbytes);
 }
 
 static void copy_kernel_hammerblade(TensorIterator& iter, bool non_blocking) {

--- a/aten/src/ATen/native/hammerblade/LLCopy.cpp
+++ b/aten/src/ATen/native/hammerblade/LLCopy.cpp
@@ -30,7 +30,7 @@ Tensor llcopy_to_hb(const Tensor& self) {
   // memcpy
   void* ptr = (void*)self.storage().data();
   void* hb_ptr = (void*)tensor.storage().data();
-  c10::hammerblade::memcpy_host_to_device(hb_ptr, ptr, storage_size);
+  c10::hammerblade::DMA_host_to_device(hb_ptr, ptr, storage_size);
 
   return tensor;
 

--- a/c10/hammerblade/HammerBladeFunctions.cpp
+++ b/c10/hammerblade/HammerBladeFunctions.cpp
@@ -50,16 +50,26 @@ void device_free(eva_t data_p) {
 
 
 void* memcpy_host_to_device(void *dst, const void *src, uint32_t nbytes) {
-  hb_mc_dma_htod_t job = {.d_addr=(eva_t)((intptr_t)dst), .h_addr=src, .size=nbytes};
-  //C10_HB_CHECK(hb_mc_device_memcpy(&_hb_device, dst, src, nbytes, HB_MC_MEMCPY_TO_DEVICE));
-  C10_HB_CHECK(hb_mc_device_dma_to_device(&_hb_device, &job, 1));
+  C10_HB_CHECK(hb_mc_device_memcpy(&_hb_device, dst, src, nbytes, HB_MC_MEMCPY_TO_DEVICE));
   return dst;
 }
 
 
 void* memcpy_device_to_host(void *dst, const void *src, uint32_t nbytes) {
+  C10_HB_CHECK(hb_mc_device_memcpy(&_hb_device, dst, src, nbytes, HB_MC_MEMCPY_TO_HOST));
+  return dst;
+}
+
+
+void* DMA_host_to_device(void *dst, const void *src, uint32_t nbytes) {
+  hb_mc_dma_htod_t job = {.d_addr=(eva_t)((intptr_t)dst), .h_addr=src, .size=nbytes};
+  C10_HB_CHECK(hb_mc_device_dma_to_device(&_hb_device, &job, 1));
+  return dst;
+}
+
+
+void* DMA_device_to_host(void *dst, const void *src, uint32_t nbytes) {
   hb_mc_dma_dtoh_t job = {.d_addr=(eva_t)((intptr_t)src), .h_addr=dst, .size=nbytes};
-  //C10_HB_CHECK(hb_mc_device_memcpy(&_hb_device, dst, src, nbytes, HB_MC_MEMCPY_TO_HOST));
   C10_HB_CHECK(hb_mc_device_dma_to_host(&_hb_device, &job, 1));
   return dst;
 }

--- a/c10/hammerblade/HammerBladeFunctions.cpp
+++ b/c10/hammerblade/HammerBladeFunctions.cpp
@@ -50,13 +50,17 @@ void device_free(eva_t data_p) {
 
 
 void* memcpy_host_to_device(void *dst, const void *src, uint32_t nbytes) {
-  C10_HB_CHECK(hb_mc_device_memcpy(&_hb_device, dst, src, nbytes, HB_MC_MEMCPY_TO_DEVICE));
+  hb_mc_dma_htod_t job = {.d_addr=(eva_t)((intptr_t)dst), .h_addr=src, .size=nbytes};
+  //C10_HB_CHECK(hb_mc_device_memcpy(&_hb_device, dst, src, nbytes, HB_MC_MEMCPY_TO_DEVICE));
+  C10_HB_CHECK(hb_mc_device_dma_to_device(&_hb_device, &job, 1));
   return dst;
 }
 
 
 void* memcpy_device_to_host(void *dst, const void *src, uint32_t nbytes) {
-  C10_HB_CHECK(hb_mc_device_memcpy(&_hb_device, dst, src, nbytes, HB_MC_MEMCPY_TO_HOST));
+  hb_mc_dma_dtoh_t job = {.d_addr=(eva_t)((intptr_t)src), .h_addr=dst, .size=nbytes};
+  //C10_HB_CHECK(hb_mc_device_memcpy(&_hb_device, dst, src, nbytes, HB_MC_MEMCPY_TO_HOST));
+  C10_HB_CHECK(hb_mc_device_dma_to_host(&_hb_device, &job, 1));
   return dst;
 }
 

--- a/c10/hammerblade/HammerBladeFunctions.h
+++ b/c10/hammerblade/HammerBladeFunctions.h
@@ -35,6 +35,8 @@ C10_HAMMERBLADE_API eva_t device_malloc(size_t nbytes);
 C10_HAMMERBLADE_API void device_free(eva_t data);
 C10_HAMMERBLADE_API void* memcpy_host_to_device(void *dst, const void *src, uint32_t nbytes);
 C10_HAMMERBLADE_API void* memcpy_device_to_host(void *dst, const void *src, uint32_t nbytes);
+C10_HAMMERBLADE_API void* DMA_host_to_device(void *dst, const void *src, uint32_t nbytes);
+C10_HAMMERBLADE_API void* DMA_device_to_host(void *dst, const void *src, uint32_t nbytes);
 C10_HAMMERBLADE_API void offload_kernel(const char* kernel, std::vector<eva_t> args);
 
 }} // namespace c10::hammerblade

--- a/c10/hammerblade/emul/bsg_manycore_cuda.cpp
+++ b/c10/hammerblade/emul/bsg_manycore_cuda.cpp
@@ -360,3 +360,68 @@ void reset_runtime() {
           binary_loaded = false;
           return HB_MC_SUCCESS;
         }
+
+
+
+
+
+        /**
+         * Copy data using DMA from the host to the device.
+         * @param[in] device  Pointer to device
+         * @param[in] jobs    Vector of host-to-device DMA jobs
+         * @param[in] count   Number of host-to-device jobs
+         */
+        int hb_mc_device_dma_to_device (hb_mc_device_t *device,
+                                        const hb_mc_dma_htod_t *jobs,
+                                        size_t count)
+        {
+          EMUL_WARNING();
+          int err;
+          // for each job...
+          for (size_t i = 0; i < count; i++) {
+            const hb_mc_dma_htod_t *dma = &jobs[i];
+            err = hb_mc_device_memcpy
+                    (device,
+                     (void*)((intptr_t)dma->d_addr),
+                     dma->h_addr,
+                     dma->size,
+                     HB_MC_MEMCPY_TO_DEVICE);
+
+            if (err != HB_MC_SUCCESS) {
+              return err;
+            }
+          }
+          return HB_MC_SUCCESS;
+        }
+
+
+
+
+        /**
+         * Copy data using DMA from the device to the host.
+         * @param[in] device  Pointer to device
+         * @param[in] jobs    Vector of device-to-host DMA jobs
+         * @param[in] count   Number of device-to-host jobs
+         */
+        int hb_mc_device_dma_to_host(hb_mc_device_t *device,
+                                     const hb_mc_dma_dtoh_t *jobs,
+                                     size_t count)
+        {
+          EMUL_WARNING();
+          int err;
+          // for each job...
+          for (size_t i = 0; i < count; i++) {
+            const hb_mc_dma_dtoh_t *dma = &jobs[i];
+            err = hb_mc_device_memcpy
+                    (device,
+                     dma->h_addr,
+                     (void*)((intptr_t)dma->d_addr),
+                     dma->size,
+                     HB_MC_MEMCPY_TO_HOST);
+
+            if (err != HB_MC_SUCCESS) {
+              return err;
+            }
+          }
+          return HB_MC_SUCCESS;
+        }

--- a/c10/hammerblade/emul/bsg_manycore_cuda.h
+++ b/c10/hammerblade/emul/bsg_manycore_cuda.h
@@ -336,6 +336,39 @@ typedef int hb_mc_manycore_id_t;
         void reset_runtime();
 
 
+        /***********/
+        /* DMA API */
+        /***********/
+        typedef struct {
+                hb_mc_eva_t d_addr; //!< Target EVA on the manycore
+                const void* h_addr; //!< Target address on the host
+                size_t      size;   //!< Size in bytes of the buffer to be copied
+        } hb_mc_dma_htod_t;
+
+        typedef struct {
+                hb_mc_eva_t d_addr; //!< Target EVA on the manycore
+                void*       h_addr; //!< Target address on the host
+                size_t      size;   //!< Size in bytes of the buffer to be copied
+        } hb_mc_dma_dtoh_t;
+
+        /**
+         * Copy data using DMA from the host to the device.
+         * @param[in] device  Pointer to device
+         * @param[in] jobs    Vector of host-to-device DMA jobs
+         * @param[in] count   Number of host-to-device jobs
+         */
+        __attribute__((warn_unused_result))
+        int hb_mc_device_dma_to_device(hb_mc_device_t *device, const hb_mc_dma_htod_t *jobs, size_t count);
+
+        /**
+         * Copy data using DMA from the host to the device.
+         * @param[in] device  Pointer to device
+         * @param[in] jobs    Vector of device-to-host DMA jobs
+         * @param[in] count   Number of device-to-host jobs
+         */
+        __attribute__((warn_unused_result))
+        int hb_mc_device_dma_to_host(hb_mc_device_t *device, const hb_mc_dma_dtoh_t *jobs, size_t count);
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
In this PR:
 - Emulate DMA APIs
 - Move tensor data around with DMA -- but we still do memcpy on metadata and scalars.