### PR TITLE
[emul] make sure there is no concurrent tile group execution

### DIFF
--- a/c10/hammerblade/emul/kernel_trampoline.cpp
+++ b/c10/hammerblade/emul/kernel_trampoline.cpp
@@ -1,5 +1,8 @@
-#include <iostream>
+#include <c10/util/Exception.h>
 #include <kernel_trampoline.h>
+
+#include <iostream>
+#include <atomic>
 
 std::map<std::string, std::function<int(uint32_t, uint64_t*)>> kernelMap;
 std::vector<std::function<int(uint32_t, uint64_t*)>> enqueued_kernel;
@@ -10,6 +13,10 @@ std::vector<uint64_t*> enqueued_argv;
 #ifdef HB_ENABLE_KERNEL_LOG
 KernelLogger kernel_call_logger(false);
 #endif
+
+const int IDLE = -1;
+const int IN_USE = -42;
+std::atomic<int> hb_device_status{IDLE};
 
 void enqueue_kernel(const std::string &kernel, uint32_t argc, uint64_t* argv) {
   assert (kernelMap.find(kernel) != kernelMap.end());
@@ -36,8 +43,18 @@ int execute_kernels() {
     return HB_MC_FAIL;
   }
 
+  int idle = IDLE;
+  if (!hb_device_status.compare_exchange_strong(idle, IN_USE)) {
+    TORCH_CHECK(false, "HB device is already in use")
+  }
+
   for (int i=0; i<enqueued_kernel.size(); i++) {
     enqueued_kernel[i](enqueued_argc[i], enqueued_argv[i]);
+  }
+
+  int in_use = IN_USE;
+  if (!hb_device_status.compare_exchange_strong(in_use, IDLE)) {
+    TORCH_CHECK(false, "HB device is not in use, how is this possible?")
   }
 
   while (!enqueued_kernel.empty()) {

--- a/c10/hammerblade/emul/kernel_trampoline.cpp
+++ b/c10/hammerblade/emul/kernel_trampoline.cpp
@@ -44,18 +44,16 @@ int execute_kernels() {
   }
 
   int idle = IDLE;
-  if (!hb_device_status.compare_exchange_strong(idle, IN_USE)) {
-    TORCH_CHECK(false, "HB device is already in use")
-  }
+  TORCH_CHECK(hb_device_status.compare_exchange_strong(idle, IN_USE),
+      "HB device is already in use");
 
   for (int i=0; i<enqueued_kernel.size(); i++) {
     enqueued_kernel[i](enqueued_argc[i], enqueued_argv[i]);
   }
 
   int in_use = IN_USE;
-  if (!hb_device_status.compare_exchange_strong(in_use, IDLE)) {
-    TORCH_CHECK(false, "HB device is not in use, how is this possible?")
-  }
+  TORCH_CHECK(hb_device_status.compare_exchange_strong(in_use, IDLE),
+      "HB device is not in use, how is this possible?");
 
   while (!enqueued_kernel.empty()) {
     enqueued_kernel.pop_back();


### PR DESCRIPTION
Although it is very unlikely ... but added a check to make sure we won't try executing more than one tile group with HB emul