### PR TITLE
Move concurrency check to offload kernel

### DIFF
--- a/c10/hammerblade/HammerBladeFunctions.cpp
+++ b/c10/hammerblade/HammerBladeFunctions.cpp
@@ -1,11 +1,17 @@
 #include "HammerBladeFunctions.h"
 #include <c10/probe/HBProfiler.h>
+#include <c10/util/Exception.h>
 
+#include <atomic>
 #include <mutex>
 #include <string>
 
 namespace c10 {
 namespace hammerblade {
+
+const int IDLE = -1;
+const int IN_USE = -42;
+std::atomic<int> hb_device_status{IDLE};
 
 namespace {
 static std::once_flag init_flag;
@@ -76,6 +82,11 @@ void* DMA_device_to_host(void *dst, const void *src, uint32_t nbytes) {
 
 
 void offload_kernel(const char* kernel, std::vector<eva_t> args) {
+
+  int idle = IDLE;
+  TORCH_CHECK(hb_device_status.compare_exchange_strong(idle, IN_USE),
+      "HB device is already in use");
+
   std::string kernel_str = "offload_kernel_";
   kernel_str += kernel;
   c10::probe::LogATenKernelWithName(kernel_str);
@@ -94,6 +105,11 @@ void offload_kernel(const char* kernel, std::vector<eva_t> args) {
   C10_HB_CHECK(hb_mc_device_tile_groups_execute(&_hb_device));
 
   free(cuda_argv);
+
+  int in_use = IN_USE;
+  TORCH_CHECK(hb_device_status.compare_exchange_strong(in_use, IDLE),
+      "HB device is not in use, how is this possible?");
+
 }
 
 

--- a/c10/hammerblade/HammerBladeFunctions.h
+++ b/c10/hammerblade/HammerBladeFunctions.h
@@ -12,6 +12,7 @@
 #include <c10/hammerblade/HammerBladeDevice.h>
 #include <c10/hammerblade/HammerBladeException.h>
 #include <c10/core/Device.h>
+#include <atomic>
 
 /*
  * inlcude bsg_manycore.h here

--- a/c10/hammerblade/HammerBladeFunctions.h
+++ b/c10/hammerblade/HammerBladeFunctions.h
@@ -39,4 +39,6 @@ C10_HAMMERBLADE_API void* DMA_host_to_device(void *dst, const void *src, uint32_
 C10_HAMMERBLADE_API void* DMA_device_to_host(void *dst, const void *src, uint32_t nbytes);
 C10_HAMMERBLADE_API void offload_kernel(const char* kernel, std::vector<eva_t> args);
 
+extern std::atomic<int> hb_device_status;
+
 }} // namespace c10::hammerblade

--- a/c10/hammerblade/emul/kernel_trampoline.cpp
+++ b/c10/hammerblade/emul/kernel_trampoline.cpp
@@ -1,8 +1,6 @@
-#include <c10/util/Exception.h>
 #include <kernel_trampoline.h>
 
 #include <iostream>
-#include <atomic>
 
 std::map<std::string, std::function<int(uint32_t, uint64_t*)>> kernelMap;
 std::vector<std::function<int(uint32_t, uint64_t*)>> enqueued_kernel;
@@ -13,10 +11,6 @@ std::vector<uint64_t*> enqueued_argv;
 #ifdef HB_ENABLE_KERNEL_LOG
 KernelLogger kernel_call_logger(false);
 #endif
-
-const int IDLE = -1;
-const int IN_USE = -42;
-std::atomic<int> hb_device_status{IDLE};
 
 void enqueue_kernel(const std::string &kernel, uint32_t argc, uint64_t* argv) {
   assert (kernelMap.find(kernel) != kernelMap.end());
@@ -42,17 +36,9 @@ int execute_kernels() {
     return HB_MC_FAIL;
   }
 
-  int idle = IDLE;
-  TORCH_CHECK(hb_device_status.compare_exchange_strong(idle, IN_USE),
-      "HB device is already in use");
-
   for (int i=0; i<enqueued_kernel.size(); i++) {
     enqueued_kernel[i](enqueued_argc[i], enqueued_argv[i]);
   }
-
-  int in_use = IN_USE;
-  TORCH_CHECK(hb_device_status.compare_exchange_strong(in_use, IDLE),
-      "HB device is not in use, how is this possible?");
 
   while (!enqueued_kernel.empty()) {
     enqueued_kernel.pop_back();


### PR DESCRIPTION
Re-think about #94 ... it would be better to do the check in `offload_kernel`