### PR TITLE
[emul] bring back emulation layer debug print

### DIFF
--- a/c10/hammerblade/emul/kernel_trampoline.cpp
+++ b/c10/hammerblade/emul/kernel_trampoline.cpp
@@ -17,6 +17,9 @@ void enqueue_kernel(const std::string &kernel, uint32_t argc, uint64_t* argv) {
   enqueued_argc.push_back(argc);
   enqueued_argv.push_back(argv);
   enqueued_kernel.push_back(kernelMap[kernel]);
+  if(const char* env_p = std::getenv("EMUL_DEBUG")) {
+    std::cerr << "Emulation layer enqueued kernel " << kernel << std::endl;
+  }
 }
 
 int execute_kernels() {

--- a/c10/hammerblade/emul/kernel_trampoline.cpp
+++ b/c10/hammerblade/emul/kernel_trampoline.cpp
@@ -17,7 +17,7 @@ void enqueue_kernel(const std::string &kernel, uint32_t argc, uint64_t* argv) {
   enqueued_argc.push_back(argc);
   enqueued_argv.push_back(argv);
   enqueued_kernel.push_back(kernelMap[kernel]);
-  if(const char* env_p = std::getenv("EMUL_DEBUG")) {
+  if(const char* env_p = std::getenv("HBEMUL_DEBUG")) {
     std::cerr << "Emulation layer enqueued kernel " << kernel << std::endl;
   }
 }


### PR DESCRIPTION
This PR brings back the `Emulation layer enqueued kernel xxxx` prints, but only if set `EMUL_DEBUG` environment variable.