### PR TITLE
fix building without HB

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -132,7 +132,7 @@ option(USE_HB_EMUL "Use HammerBlade Emulation Layer" OFF)
 option(PROFILE_ATEN "Turn on ATen kernel profiling" ON)
 cmake_dependent_option(
   HB_REDISPATCH "Enable conditional redispatch to HB" ON
-  "PROFILE_ATEN" OFF)
+  "PROFILE_ATEN;USE_HB" OFF)
 cmake_dependent_option(
   HB_ENABLE_KERNEL_LOG "Enable HammerBlade kernel call logging" ON
   "USE_HB_EMUL" OFF)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ This work aims to port PyTorch to HammerBlade.
 
       python setup.py develop
 
+- Turn on emulation debug info
+      export HBEMUL_DEBUG=1
+
 [venv]: https://docs.python.org/3/tutorial/venv.html
 
 ### Run Pytests

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -120,6 +120,7 @@ c10::probe::LogATenKernel();
     ${named_guard_declaration}
 #endif
     ${device_guard_declaration}
+#ifdef HB_REDISPATCH
     if(!${redispatch_condition}) {
       ${return_call} at::native::${native_type_method_dispatch}(${native_actuals});
     } else {
@@ -128,6 +129,9 @@ c10::probe::LogATenKernel();
       at::native::${native_type_method_dispatch}(${alter_actuals});
       TORCH_CHECK(false, "Termination after redispatching");
     }
+#else
+    ${return_call} at::native::${native_type_method_dispatch}(${native_actuals});
+#endif
 }
 """)
 
@@ -153,6 +157,7 @@ c10::probe::LogATenKernel();
     ${named_guard_declaration}
 #endif
     ${device_guard_declaration}
+#ifdef HB_REDISPATCH
     if(!${redispatch_condition}) {
         ${return_call} at::native::${native_type_method_dispatch}(${native_actuals});
     } else {
@@ -161,6 +166,9 @@ c10::probe::LogATenKernel();
         at::native::${alter_method_dispatch}(${alter_actuals});
         TORCH_CHECK(false, "Termination after redispatching");
     }
+#else
+    ${return_call} at::native::${native_type_method_dispatch}(${native_actuals});
+#endif
 }
 """)
 

--- a/aten/src/ATen/native/LLCopy.cpp
+++ b/aten/src/ATen/native/LLCopy.cpp
@@ -1,13 +1,16 @@
 #include <ATen/ATen.h>
 #include <ATen/Dispatch.h>
 #include <ATen/native/Resize.h>
+#ifdef USE_HB
 #include <ATen/hammerblade/HammerBladeContext.h>
+#endif
 
 namespace at {
 namespace native {
 
 Tensor llcopy_to_hb(const Tensor& self) {
 
+#ifdef USE_HB
   // get low level storage size
   size_t itemsize = self.storage().itemsize();
   int64_t numel = self.storage().numel();
@@ -33,6 +36,12 @@ Tensor llcopy_to_hb(const Tensor& self) {
   c10::hammerblade::DMA_host_to_device(hb_ptr, ptr, storage_size);
 
   return tensor;
+
+#else
+
+  TORCH_CHECK(false, "cannot call llcopy_to_hb if not using HB");
+
+#endif
 
 }
 

--- a/caffe2/CMakeLists.txt
+++ b/caffe2/CMakeLists.txt
@@ -1065,6 +1065,7 @@ endif()
 
 if(USE_HB)
   target_link_libraries(torch PUBLIC c10_hammerblade)
+  target_compile_definitions(torch PRIVATE USE_HB)
 endif()
 
 target_link_libraries(torch PUBLIC c10_probe)

--- a/torch/hb_profiler.py
+++ b/torch/hb_profiler.py
@@ -58,6 +58,8 @@ class ProfilerTopLvlFuncRecord(ProfilerRecord):
 
 def enable():
     profiler_status.is_in_ROI = True
+    if torch._C.get_num_threads() != 1:
+        print("Warning: HBProfiler is thread safe only if OMP is used")
     torch._C._hb_profiler_start()
 
 def disable():


### PR DESCRIPTION
Fixed a bug in which llcopy prevents pytorch from building correctly when USE_HB is set to OFF.