### PR TITLE
Fix logical linear indexing to nD conversion

### DIFF
--- a/hammerblade/torch/kernel/hb_parallel_for.hpp
+++ b/hammerblade/torch/kernel/hb_parallel_for.hpp
@@ -22,9 +22,9 @@ inline uint32_t offset_calc(uint32_t idx, HBTensor<scalar_t> tensor) {
   uint32_t factor = 1;
   uint32_t offset = 0;
   for(int32_t i = tensor.ndim() - 1; i >= 0; i--) {
+    idx /= factor;
     uint32_t dimx = idx % sizes[i];
     offset += dimx * strides[i];
-    idx /= factor;
     factor *= sizes[i];
   }
   return offset;

--- a/hammerblade/torch/kernel/hb_parallel_for.hpp
+++ b/hammerblade/torch/kernel/hb_parallel_for.hpp
@@ -19,12 +19,11 @@ template<typename scalar_t>
 inline uint32_t offset_calc(uint32_t idx, HBTensor<scalar_t> tensor) {
   uint32_t* strides = tensor.get_strides();
   uint32_t* sizes = tensor.get_sizes();
-  uint32_t factor = 1;
   uint32_t offset = 0;
   for(int32_t i = tensor.ndim() - 1; i >= 0; i--) {
-    uint32_t dimx = (idx / factor) % sizes[i];
+    uint32_t dimx = idx % sizes[i];
+    idx /= sizes[i];
     offset += dimx * strides[i];
-    factor *= sizes[i];
   }
   return offset;
 }

--- a/hammerblade/torch/kernel/hb_parallel_for.hpp
+++ b/hammerblade/torch/kernel/hb_parallel_for.hpp
@@ -22,8 +22,7 @@ inline uint32_t offset_calc(uint32_t idx, HBTensor<scalar_t> tensor) {
   uint32_t factor = 1;
   uint32_t offset = 0;
   for(int32_t i = tensor.ndim() - 1; i >= 0; i--) {
-    idx /= factor;
-    uint32_t dimx = idx % sizes[i];
+    uint32_t dimx = (idx / factor) % sizes[i];
     offset += dimx * strides[i];
     factor *= sizes[i];
   }

--- a/hammerblade/torch/tests/test_contiguous.py
+++ b/hammerblade/torch/tests/test_contiguous.py
@@ -38,3 +38,21 @@ def test_torch_contiguous_4():
     assert y.device == torch.device("hammerblade")
     assert y.is_contiguous()
     assert torch.equal(x.t(), y.cpu())
+
+def test_torch_contiguous_5():
+    x = torch.randn(3, 3)
+    h = x.hammerblade().t()
+    assert not h.is_contiguous()
+    y = h.contiguous()
+    assert y.device == torch.device("hammerblade")
+    assert y.is_contiguous()
+    assert torch.equal(x.t(), y.cpu())
+
+def test_torch_contiguous_6():
+    x = torch.randn(2, 9)
+    h = x.hammerblade().t()
+    assert not h.is_contiguous()
+    y = h.contiguous()
+    assert y.device == torch.device("hammerblade")
+    assert y.is_contiguous()
+    assert torch.equal(x.t(), y.cpu())

--- a/hammerblade/torch/tests/test_contiguous.py
+++ b/hammerblade/torch/tests/test_contiguous.py
@@ -56,3 +56,12 @@ def test_torch_contiguous_6():
     assert y.device == torch.device("hammerblade")
     assert y.is_contiguous()
     assert torch.equal(x.t(), y.cpu())
+
+def test_torch_contiguous_7():
+    x = torch.randn(2, 3, 4, 5, 6, 7)
+    h = x.hammerblade().transpose(3, 5)
+    assert not h.is_contiguous()
+    y = h.contiguous()
+    assert y.device == torch.device("hammerblade")
+    assert y.is_contiguous()
+    assert torch.equal(x.transpose(3, 5), y.cpu())


### PR DESCRIPTION
 This appears to be a very fundamental bug ... in which logical linear to actual offset conversion was done incorrectly. not sure how did we get away from it ...

The conversion logic is similar to
https://stackoverflow.com/questions/12429492/how-to-convert-a-monodimensional-index-to-corresponding-indices-in-a-multidimens