### PR TITLE
Fallback to CPU automatically if an ATen OP is not implemented for HB

### DIFF
--- a/aten/src/ATen/core/dispatch/Dispatcher.h
+++ b/aten/src/ATen/core/dispatch/Dispatcher.h
@@ -226,17 +226,6 @@ inline void Dispatcher::callBoxed(const OperatorHandle& op, Stack* stack) const 
 
 inline const KernelFunction& Dispatcher::dispatch_(const DispatchTable& dispatchTable, const ska::flat_hash_map<TensorTypeId, KernelFunction>& backendFallbackKernels, c10::optional<TensorTypeId> dispatchKey) {
 
-#ifdef PROFILE_ATEN
-  if (c10::probe::hb_profiler_is_in_roi()) {
-    auto HBKernel = dispatchTable.lookup(c10::TensorTypeId::HammerBladeTensorId);
-    auto HBFallbackKernel = backendFallbackKernels.find(c10::TensorTypeId::HammerBladeTensorId);
-    auto catchallKernel = dispatchTable.lookupCatchallKernel();
-    if (HBKernel == nullptr && HBFallbackKernel == backendFallbackKernels.end() && catchallKernel == nullptr) {
-      c10::probe::log_unimpl_kernel(dispatchTable.operatorName());
-    }
-  }
-#endif
-
   if (C10_LIKELY(dispatchKey.has_value())) {
     const KernelFunction* backendKernel = dispatchTable.lookup(*dispatchKey);
 

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1452,7 +1452,7 @@ TensorList {0}_hb = TensorList({0}_hb_vec);
         def process_fallback_hb_to_cpu(option):
             # type: (FunctionOption) -> None
             option['fallback_warning'] = "std::cerr << \"ATen OP {0} falls back to CPU\" << std::endl;\n".format(option['api_name'])
-            fallback_condition = "(c10::probe::use_hb_redispatch() && c10::probe::hb_profiler_is_in_roi() && c10::probe::hb_profiler_is_top_level())"
+            fallback_condition = "(c10::probe::use_hb_redispatch() && c10::probe::hb_profiler_is_in_roi() && c10::probe::hb_profiler_is_top_level() && c10::probe::fallback_is_enabled())"
             fallback_boxing = ""
             fallback_unboxing = ""
             fallback_actuals = []
@@ -2104,7 +2104,7 @@ TensorList {0}_hb = TensorList({0}_hb_vec);
     def process_fallback_hb_to_cpu(option):
         # type: (FunctionOption) -> None
         option['fallback_warning'] = "std::cerr << \"ATen OP {0} falls back to CPU\" << std::endl;\n".format(option['api_name'])
-        fallback_condition = "(c10::probe::use_hb_redispatch() && c10::probe::hb_profiler_is_in_roi() && c10::probe::hb_profiler_is_top_level())"
+        fallback_condition = "(c10::probe::use_hb_redispatch() && c10::probe::hb_profiler_is_in_roi() && c10::probe::hb_profiler_is_top_level() && c10::probe::fallback_is_enabled())"
         fallback_boxing = ""
         fallback_unboxing = ""
         fallback_actuals = []

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -195,7 +195,7 @@ c10::probe::LogATenKernel();
     ${device_guard_declaration}
 #ifdef HB_REDISPATCH
     if(!${fallback_condition}) {
-        TORCH_CHECK(false, "Not implemented for HB, and Fallback is not enabled");
+        TORCH_CHECK(false, "${api_name} is not implemented for HB, and Fallback is not enabled");
     } else {
         ${fallback_warning}
         ${fallback_boxing}
@@ -204,7 +204,7 @@ c10::probe::LogATenKernel();
         ${fallback_ret_call}
     }
 #else
-    TORCH_CHECK(false, "Not implemented for HB, and Fallback is not enabled");
+    TORCH_CHECK(false, "${api_name} is not implemented for HB, and Fallback is not enabled");
 #endif
 }
 """)
@@ -2201,6 +2201,13 @@ TensorList {0}_cpu = TensorList({0}_cpu_vec);
                     process_fallback_hb_to_cpu(option)
                     type_object_definitions.append(
                         NATIVE_DISPATCH_DEFINITION_BACKEND_FALLBACK.substitute(env))
+                    if option['use_c10_dispatcher'] == 'full':
+                        function_registrations.append(
+                            BACKEND_FUNCTION_REGISTRATION.substitute(env))
+                    else:
+                        assert option['use_c10_dispatcher'] == 'unboxed_only'
+                        function_registrations.append(
+                            BACKEND_UNBOXEDONLY_FUNCTION_REGISTRATION.substitute(env))
 
     for declaration in declarations:
         for option in declaration['options']:

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -125,7 +125,9 @@ c10::probe::LogATenKernel();
       try {
         ${return_call} at::native::${native_type_method_dispatch}(${native_actuals});
       } catch(const c10::Error& c10_error) {
-        if(${fallback_condition}) {
+        if(${fallback_condition} &&
+          (c10_error.msg_without_backtrace().find("missing HammerBlade kernel") != std::string::npos
+           || c10_error.msg_without_backtrace().find("is not implemented for HB, and Fallback is not enabled") != std::string::npos)) {
           ${fallback_warning}
           ${fallback_boxing}
           ${fallback_ret_val} at::native::${native_type_method_dispatch}(${fallback_actuals});

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1460,18 +1460,18 @@ TensorList {0}_hb = TensorList({0}_hb_vec);
             non_const_tensor = 0
             for f in option['formals_list']:
                 if f['type'] == 'Tensor &':
-                    fallback_boxing += "auto {0}_cpu = {0}.cpu();\n".format(f['name'])
+                    fallback_boxing += "auto {0}_cpu = {0}.cpu_ifdef();\n".format(f['name'])
                     fallback_unboxing += "{0}.copy_({0}_cpu.hammerblade());\n".format(f['name'])
                     fallback_actuals.append(f['name'] + "_cpu")
                     non_const_tensor += 1
                 elif f['type'] == 'const Tensor &':
-                    fallback_actuals.append(f['name'] + ".cpu()")
+                    fallback_actuals.append(f['name'] + ".cpu_ifdef()")
                 elif f['type'] == 'TensorList':
                     fallback_boxing += """
 std::vector<Tensor> {0}_vec = {0}.vec();
 std::vector<Tensor> {0}_cpu_vec;
 for (const auto& t : {0}_vec) {{
-  {0}_cpu_vec.push_back(t.cpu());
+  {0}_cpu_vec.push_back(t.cpu_ifdef());
 }}
 TensorList {0}_cpu = TensorList({0}_cpu_vec);
 \n""".format(f['name'])
@@ -2112,18 +2112,18 @@ TensorList {0}_hb = TensorList({0}_hb_vec);
         non_const_tensor = 0
         for f in option['formals_list']:
             if f['type'] == 'Tensor &':
-                fallback_boxing += "auto {0}_cpu = {0}.cpu();\n".format(f['name'])
+                fallback_boxing += "auto {0}_cpu = {0}.cpu_ifdef();\n".format(f['name'])
                 fallback_unboxing += "{0}.copy_({0}_cpu.hammerblade());\n".format(f['name'])
                 fallback_actuals.append(f['name'] + "_cpu")
                 non_const_tensor += 1
             elif f['type'] == 'const Tensor &':
-                fallback_actuals.append(f['name'] + ".cpu()")
+                fallback_actuals.append(f['name'] + ".cpu_ifdef()")
             elif f['type'] == 'TensorList':
                 fallback_boxing += """
 std::vector<Tensor> {0}_vec = {0}.vec();
 std::vector<Tensor> {0}_cpu_vec;
 for (const auto& t : {0}_vec) {{
-  {0}_cpu_vec.push_back(t.cpu());
+  {0}_cpu_vec.push_back(t.cpu_ifdef());
 }}
 TensorList {0}_cpu = TensorList({0}_cpu_vec);
 \n""".format(f['name'])

--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -1451,7 +1451,7 @@ TensorList {0}_hb = TensorList({0}_hb_vec);
 
         def process_fallback_hb_to_cpu(option):
             # type: (FunctionOption) -> None
-            option['fallback_warning'] = "std::cerr << \"ATen OP {0} falls back to CPU\" << std::endl;\n".format(option['api_name'])
+            option['fallback_warning'] = "std::cerr << \"ATen OP {0} falls back to CPU: \" << c10_error.msg_without_backtrace() << std::endl;\n".format(option['api_name'])
             fallback_condition = "(c10::probe::use_hb_redispatch() && c10::probe::hb_profiler_is_in_roi() && c10::probe::hb_profiler_is_top_level() && c10::probe::fallback_is_enabled())"
             fallback_boxing = ""
             fallback_unboxing = ""

--- a/aten/src/ATen/gen.py
+++ b/aten/src/ATen/gen.py
@@ -306,6 +306,7 @@ def generate_storage_type_and_tensor(backend, density, declarations):
 
     if env['Backend'] == 'HammerBlade':
         env['namespace'] = env['Backend'].lower()
+        env['legacy_th_headers'].append('#include <ATen/LegacyTHFunctionsCPU.h>')
 
     if density != 'Sparse':
         fm.write(env['Type'] + ".cpp", TYPE_DERIVED_CPP, env)

--- a/aten/src/ATen/native/LLCopy.cpp
+++ b/aten/src/ATen/native/LLCopy.cpp
@@ -11,6 +11,10 @@ namespace native {
 Tensor llcopy_to_hb(const Tensor& self) {
 
 #ifdef USE_HB
+  // if tensor is not defined, just return it
+  if (!self.defined()) {
+    return self;
+  }
   // get low level storage size
   size_t itemsize = self.storage().itemsize();
   int64_t numel = self.storage().numel();

--- a/aten/src/ATen/templates/TensorBody.h
+++ b/aten/src/ATen/templates/TensorBody.h
@@ -394,6 +394,7 @@ class CAFFE2_API Tensor {
   Tensor operator[](int64_t index) const;
 
   Tensor cpu() const;
+  Tensor cpu_ifdef() const;
   Tensor cuda() const;
   Tensor hip() const;
   Tensor hammerblade() const;

--- a/aten/src/ATen/templates/TensorMethods.h
+++ b/aten/src/ATen/templates/TensorMethods.h
@@ -31,6 +31,15 @@ inline Tensor Tensor::cpu() const {
   return to(options().device(DeviceType::CPU), /*non_blocking*/ false, /*copy*/ false);
 }
 
+// Do copy to CPU only if the tensor is defined
+inline Tensor Tensor::cpu_ifdef() const {
+  if (this->defined()) {
+    return to(options().device(DeviceType::CPU), /*non_blocking*/ false, /*copy*/ false);
+  } else {
+    return *this;
+  }
+}
+
 // TODO: The Python version also accepts arguments
 inline Tensor Tensor::cuda() const {
   return to(options().device(DeviceType::CUDA), /*non_blocking*/ false, /*copy*/ false);

--- a/c10/probe/Fallback.cpp
+++ b/c10/probe/Fallback.cpp
@@ -1,0 +1,22 @@
+#include <c10/probe/Fallback.h>
+
+namespace c10 {
+namespace probe {
+
+Fallback g_fallback;
+
+// ========== Fallback C10_API ==========
+
+void fallback_enable() {
+  g_fallback.enable();
+}
+
+void fallback_disable() {
+  g_fallback.disable();
+}
+
+bool fallback_is_enabled() {
+  return g_fallback.is_enabled();
+}
+
+}} // namespace c10::probe

--- a/c10/probe/Fallback.h
+++ b/c10/probe/Fallback.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <c10/probe/ProbeMacros.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace c10 {
+namespace probe {
+
+class Fallback {
+public:
+  Fallback() : enabled(false) {}
+  ~Fallback() = default;
+  void enable() {enabled = true;}
+  void disable() {enabled = false;}
+  bool is_enabled() {return enabled;}
+private:
+  bool enabled;
+};
+
+C10_PROBE_API void fallback_enable();
+C10_PROBE_API void fallback_disable();
+C10_PROBE_API bool fallback_is_enabled();
+
+extern Fallback g_fallback;
+
+}} // namespace c10::probe

--- a/c10/probe/HBProfiler.h
+++ b/c10/probe/HBProfiler.h
@@ -5,6 +5,7 @@
 #include <c10/probe/ExecutionTime.h>
 #include <c10/probe/Chart.h>
 #include <c10/probe/Route.h>
+#include <c10/probe/Fallback.h>
 
 #include <map>
 #include <string>

--- a/hammerblade/torch/tests/test_fallback.py
+++ b/hammerblade/torch/tests/test_fallback.py
@@ -12,7 +12,7 @@ torch.manual_seed(42)
 random.seed(42)
 
 def test_typedefault_1():
-    x = torch.tensor([ 0.2341,  0.2539, -0.6256, -0.6448])
+    x = torch.tensor([0.2341, 0.2539, -0.6256, -0.6448])
     cpu = torch.atan(x)
     torch.hammerblade.profiler.enable()
     torch.hammerblade.profiler.fallback.enable()
@@ -23,7 +23,7 @@ def test_typedefault_1():
 
 @pytest.mark.xfail
 def test_typedefault_1F():
-    x = tensor([ 0.2341,  0.2539, -0.6256, -0.6448])
+    x = tensor([0.2341, 0.2539, -0.6256, -0.6448])
     cpu = torch.atan(x)
     torch.hammerblade.profiler.enable()
     hb = torch.atan(x.hammerblade())

--- a/hammerblade/torch/tests/test_fallback.py
+++ b/hammerblade/torch/tests/test_fallback.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for torch.hammerblade.profiler.fallback
+05/18/2020 Lin Cheng (lc873@cornell.edu)
+"""
+
+import torch
+import torch.nn.functional as F
+import random
+import pytest
+
+torch.manual_seed(42)
+random.seed(42)
+
+def test_typedefault_1():
+    x = torch.tensor([ 0.2341,  0.2539, -0.6256, -0.6448])
+    cpu = torch.atan(x)
+    torch.hammerblade.profiler.enable()
+    torch.hammerblade.profiler.fallback.enable()
+    hb = torch.atan(x.hammerblade())
+    torch.hammerblade.profiler.fallback.disable()
+    torch.hammerblade.profiler.disable()
+    assert torch.allclose(hb.cpu(), cpu)
+
+@pytest.mark.xfail
+def test_typedefault_1F():
+    x = tensor([ 0.2341,  0.2539, -0.6256, -0.6448])
+    cpu = torch.atan(x)
+    torch.hammerblade.profiler.enable()
+    hb = torch.atan(x.hammerblade())
+    torch.hammerblade.profiler.disable()
+    assert torch.allclose(hb.cpu(), cpu)
+
+def test_native_1():
+    x = torch.randn(2, 3)
+    cpu = torch.cat((x, x, x), 0)
+    h = x.hammerblade()
+    torch.hammerblade.profiler.enable()
+    torch.hammerblade.profiler.fallback.enable()
+    hb = torch.cat((h, h, h), 0)
+    torch.hammerblade.profiler.fallback.disable()
+    torch.hammerblade.profiler.disable()
+    assert torch.allclose(hb.cpu(), cpu)
+
+@pytest.mark.xfail
+def test_native_1F():
+    x = torch.randn(2, 3)
+    cpu = torch.cat((x, x, x), 0)
+    h = x.hammerblade()
+    torch.hammerblade.profiler.enable()
+    hb = torch.cat((h, h, h), 0)
+    torch.hammerblade.profiler.disable()
+    assert torch.allclose(hb.cpu(), cpu)
+
+def test_complex_1():
+    input = torch.randn(3)
+    target = torch.empty(3).random_(2)
+    cpu_loss = F.binary_cross_entropy_with_logits(input, target)
+    torch.hammerblade.profiler.enable()
+    torch.hammerblade.profiler.fallback.enable()
+    hb_loss = F.binary_cross_entropy_with_logits(input.hammerblade(), target.hammerblade())
+    torch.hammerblade.profiler.fallback.disable()
+    torch.hammerblade.profiler.disable()
+    assert torch.allclose(hb_loss.cpu(), cpu_loss)
+
+@pytest.mark.xfail
+def test_complex_1F():
+    input = torch.randn(3)
+    target = torch.empty(3).random_(2)
+    cpu_loss = F.binary_cross_entropy_with_logits(input, target)
+    hb_loss = F.binary_cross_entropy_with_logits(input.hammerblade(), target.hammerblade())
+    assert torch.allclose(hb_loss.cpu(), cpu_loss)

--- a/hammerblade/torch/tests/test_llcopy.py
+++ b/hammerblade/torch/tests/test_llcopy.py
@@ -50,3 +50,14 @@ def test_normal_copy():
     h = x.hammerblade()
     assert not x.is_contiguous()
     assert h.is_contiguous()
+
+def test_llcopy_backward():
+    x1 = torch.tensor([1., 2., 3., 4.], requires_grad=True)
+    x2 = torch.tensor([1., 2., 3., 4.], requires_grad=True)
+    y1 = torch.sum(x1)
+    y2 = torch.sum(x2.hammerblade_ll())
+    assert torch.allclose(y1, y2.cpu())
+    assert y2.device == torch.device("hammerblade")
+    y1.backward()
+    y2.backward()
+    assert torch.allclose(x1.grad, x2.grad)

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -164,6 +164,9 @@
 - name: all.dim(Tensor self, int dim, bool keepdim=False) -> Tensor
   self: not_implemented("all")
 
+- name: llcopy(Tensor self) -> Tensor
+  self: grad
+
 - name: as_strided(Tensor(a) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a)
   self: as_strided_backward(grad, TensorGeometry(self), size, stride, storage_offset)
 

--- a/tools/autograd/derivatives.yaml
+++ b/tools/autograd/derivatives.yaml
@@ -165,7 +165,7 @@
   self: not_implemented("all")
 
 - name: llcopy(Tensor self) -> Tensor
-  self: grad
+  self: grad.cpu()
 
 - name: as_strided(Tensor(a) self, int[] size, int[] stride, int? storage_offset=None) -> Tensor(a)
   self: as_strided_backward(grad, TensorGeometry(self), size, stride, storage_offset)

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -543,6 +543,24 @@ static PyObject * THPModule_hbProfilerChartPrint(PyObject *module, PyObject *noa
   return PyUnicode_FromString(c10::probe::chart_print().c_str());
 }
 
+static PyObject * THPModule_hbProfilerFallbackEnable(PyObject *module, PyObject *noargs) {
+  c10::probe::fallback_enable();
+  Py_RETURN_NONE;
+}
+
+static PyObject * THPModule_hbProfilerFallbackDisable(PyObject *module, PyObject *noargs) {
+  c10::probe::fallback_disable();
+  Py_RETURN_NONE;
+}
+
+static PyObject * THPModule_hbProfilerFallbackIsEnabled(PyObject *module, PyObject *noargs) {
+  if (c10::probe::fallback_is_enabled()) {
+    Py_RETURN_TRUE;
+  } else {
+    Py_RETURN_FALSE;
+  }
+}
+
 static PyObject * THPModule_hbProfilerAddBeacon(PyObject *_unused, PyObject *kernel_signature)
 {
   HANDLE_TH_ERRORS
@@ -632,6 +650,9 @@ static PyMethodDef TorchMethods[] = {
   {"_hb_profiler_route_add_waypoint",  (PyCFunction)THPModule_hbProfilerAddWaypoint, METH_VARARGS, nullptr},
   {"_hb_profiler_route_print",  (PyCFunction)THPModule_hbProfilerRoutePrint, METH_NOARGS, nullptr},
   {"_hb_profiler_chart_print",  (PyCFunction)THPModule_hbProfilerChartPrint, METH_NOARGS, nullptr},
+  {"_hb_profiler_fallback_enable",  (PyCFunction)THPModule_hbProfilerFallbackEnable, METH_NOARGS, nullptr},
+  {"_hb_profiler_fallback_disable",  (PyCFunction)THPModule_hbProfilerFallbackDisable, METH_NOARGS, nullptr},
+  {"_hb_profiler_fallback_is_enabled",  (PyCFunction)THPModule_hbProfilerFallbackIsEnabled, METH_NOARGS, nullptr},
 #endif
   {nullptr, nullptr, 0, nullptr}
 };

--- a/torch/hammerblade/profiler/__init__.py
+++ b/torch/hammerblade/profiler/__init__.py
@@ -5,6 +5,7 @@ import torch.hammerblade.profiler.exec_time
 import torch.hammerblade.profiler.unimpl
 import torch.hammerblade.profiler.chart
 import torch.hammerblade.profiler.route
+import torch.hammerblade.profiler.fallback
 
 class ProfilerStatus:
 

--- a/torch/hammerblade/profiler/fallback.py
+++ b/torch/hammerblade/profiler/fallback.py
@@ -1,0 +1,21 @@
+import torch
+
+# --------- torch.hb_profiler.fallback APIs ---------
+
+def enable():
+    try:
+        torch._C._hb_profiler_fallback_enable()
+    except AttributeError:
+        print("PyTorch is not built with profiling")
+
+def disable():
+    try:
+        torch._C._hb_profiler_fallback_disable()
+    except AttributeError:
+        print("PyTorch is not built with profiling")
+
+def is_enabled():
+    try:
+        return torch._C._hb_profiler_fallback_is_enabled()
+    except AttributeError:
+        print("PyTorch is not built with profiling")


### PR DESCRIPTION
If a certain ATen OP is not implemented for HB, one would have the choice to fallback to CPU.
Normal execution on HB can be resumed after falling back to CPU.

BUG fix:
 - llcopy now has a backward method -- which does nothing