### PR TITLE
HBTensor partial template specialization

### DIFF
--- a/hammerblade/torch/kernel/hb_tensor.hpp
+++ b/hammerblade/torch/kernel/hb_tensor.hpp
@@ -61,8 +61,106 @@ typedef struct {
 // allocation.
 // =========================================================
 
-template <typename DT>
+template <typename DT, uint32_t dims=-1>
 class HBTensor {
+  private:
+    uint32_t N;
+    uint32_t strides[dims];
+    uint32_t sizes[dims];
+    DT* data;
+
+  public:
+    HBTensor(hb_tensor_t* t) :
+      N(t->N),
+      data((DT*) ((intptr_t) t->data)) {
+        // WAW HW bug seems to be triggered on a non-bloacking load to
+        // the register holding `sizes` in various kernels. This fix
+        // adds a RAW dependedncy on that register, blocking the load.
+        HB_FIX_WAW_HAZARD(sizes);
+
+        hb_assert_msg(
+          t->dims == dims,
+          "error: HBTensor dims don't match offloaed tensor dims");
+
+        uint32_t* strides_remote = (uint32_t*) ((intptr_t) t->strides);
+        uint32_t* sizes_remote = (uint32_t*) ((intptr_t) t->sizes);
+
+        // Move strides and sizes to DRAM
+        for(int i=0; i<dims; ++i) {
+          strides[i] = strides_remote[i];
+          sizes[i] = sizes_remote[i];
+        }
+      }
+
+    char* data_ptr() {
+      return (char*)data;
+    }
+
+    uint32_t* get_strides() {
+      return strides;
+    }
+
+    uint32_t* get_sizes() {
+      return sizes;
+    }
+
+    int numel() {
+      return N;
+    }
+
+    uint32_t dim(uint32_t d) {
+      hb_assert_msg(d < dims,
+                    "error: dimesnion must be less than %d\n",
+                    dims);
+      return sizes[d];
+    }
+
+    uint32_t ndim() {
+      return dims;
+    }
+
+    // Special case where we want linear, 0-d
+    // and 1-d tensor indexing.
+    //
+    // XXX: The tensor has to be contiguous if
+    // it's >1-d tensor.
+    DT& operator()(uint32_t index) {
+      hb_assert_msg(index < N,
+                    "error: N=%d but accessed %d\n",
+                    N, index);
+      if(dims != 1) {
+        return data[index];
+      } else {
+        // Explicitly calculate data index to handle
+        // non-contiguous 1-d tensors.
+        return data[index * strides[0]];
+      }
+    }
+
+    template<typename... T>
+    DT& operator()(uint32_t index0, T... indices) {
+      std::initializer_list<uint32_t> iarray = {index0, indices...};
+
+      hb_assert_msg(iarray.size() == dims,
+                    "error: expected dims=%d arguments but got %d\n",
+                    dims, iarray.size());
+      uint32_t offset = 0;
+      uint32_t s = 0;
+      for(auto index : iarray) {
+        offset += (index * strides[s]);
+        s++;
+      }
+
+      hb_assert_msg(offset < N,
+                    "error: N=%d but accessed %d\n",
+                    N, offset);
+
+      return data[offset];
+    }
+};
+
+template <typename DT>
+class HBTensor<DT, -1> {
   private:
     uint32_t N;
     uint32_t dims;
@@ -149,7 +247,6 @@ class HBTensor {
       return data[offset];
     }
 };
-
 
 template<typename T>
 class HBVector {

--- a/hammerblade/torch/kernel/hb_tensor.hpp
+++ b/hammerblade/torch/kernel/hb_tensor.hpp
@@ -61,7 +61,7 @@ typedef struct {
 // allocation.
 // =========================================================
 
-template <typename DT, uint32_t dims=-1>
+template <typename DT, int32_t dims=-1>
 class HBTensor {
   private:
     uint32_t N;
@@ -73,11 +73,6 @@ class HBTensor {
     HBTensor(hb_tensor_t* t) :
       N(t->N),
       data((DT*) ((intptr_t) t->data)) {
-        // WAW HW bug seems to be triggered on a non-bloacking load to
-        // the register holding `sizes` in various kernels. This fix
-        // adds a RAW dependedncy on that register, blocking the load.
-        HB_FIX_WAW_HAZARD(sizes);
-
         hb_assert_msg(
           t->dims == dims,
           "error: HBTensor dims don't match offloaed tensor dims");

--- a/hammerblade/torch/kernel/hb_tensor.hpp
+++ b/hammerblade/torch/kernel/hb_tensor.hpp
@@ -85,7 +85,7 @@ class HBTensor {
         uint32_t* strides_remote = (uint32_t*) ((intptr_t) t->strides);
         uint32_t* sizes_remote = (uint32_t*) ((intptr_t) t->sizes);
 
-        // Move strides and sizes to DRAM
+        // Move strides and sizes to scratchpad
         for(int i=0; i<dims; ++i) {
           strides[i] = strides_remote[i];
           sizes[i] = sizes_remote[i];

--- a/hammerblade/torch/kernel/kernel_addmm.cpp
+++ b/hammerblade/torch/kernel/kernel_addmm.cpp
@@ -43,7 +43,7 @@ extern "C" {
   void dram_to_sp_simple(
           float* dest,
           float coeff,
-          HBTensor<float> src,
+          HBTensor<float, 2> src,
           int dim_y,
           int dim_x,
           int r_idx,
@@ -99,7 +99,7 @@ extern "C" {
   void dram_to_sp(
           float* dest,
           float coeff,
-          HBTensor<float> src,
+          HBTensor<float, 2> src,
           int dim_y,
           int dim_x,
           int r_idx,
@@ -129,10 +129,10 @@ extern "C" {
 
     if (__bsg_id == 0) {
 
-        auto self = HBTensor<float>(_self);
-        auto mat1 = HBTensor<float>(_mat1);
-        auto mat2 = HBTensor<float>(_mat2);
-        auto result = HBTensor<float>(_result);
+        auto self = HBTensor<float, 2>(_self);
+        auto mat1 = HBTensor<float, 2>(_mat1);
+        auto mat2 = HBTensor<float, 2>(_mat2);
+        auto result = HBTensor<float, 2>(_result);
         float beta = *_beta;
         float alpha = *_alpha;
 

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -16,9 +16,9 @@ extern "C" {
           hb_tensor_t* weight,
           hb_vector_t* padding,
           hb_vector_t* strides) {
-    auto y = HBTensor<float>(output);
-    auto x = HBTensor<float>(input);
-    auto w = HBTensor<float>(weight);
+    auto y = HBTensor<float, 4>(output);
+    auto x = HBTensor<float, 4>(input);
+    auto w = HBTensor<float, 4>(weight);
     auto p = HBVector<uint32_t>(padding);
     auto s = HBVector<uint32_t>(strides);
 

--- a/hammerblade/torch/tests/test_conv2d.py
+++ b/hammerblade/torch/tests/test_conv2d.py
@@ -162,7 +162,7 @@ def test_conv2d_bias_4():
 
     _test_conv2d(inputs, kernel, padding, stride, bias)
 
-@pytest.mark.skipif(torch.hb_emul_on, reason="Prohibitively slow on cosim")
+@pytest.mark.skipif(not torch.hb_emul_on, reason="Prohibitively slow on cosim")
 def test_conv2d_batch_input_output():
     """
     Combinations of batch, input and output channel sizes
@@ -179,7 +179,7 @@ def test_conv2d_batch_input_output():
                                     kernel_size)
                 _test_conv2d(inputs, kernel)
 
-@pytest.mark.skipif(torch.hb_emul_on, reason="Prohibitively slow on cosim")
+@pytest.mark.skipif(not torch.hb_emul_on, reason="Prohibitively slow on cosim")
 def test_conv2d_width_height_kernel():
     """
     Combinations of width, height and kernel_size
@@ -196,7 +196,7 @@ def test_conv2d_width_height_kernel():
                                     kernel_size)
                 _test_conv2d(inputs, kernel)
 
-@pytest.mark.skipif(torch.hb_emul_on, reason="Prohibitively slow on cosim")
+@pytest.mark.skipif(not torch.hb_emul_on, reason="Prohibitively slow on cosim")
 def test_conv2d_width_height_kernel_pad_stride():
     """
     Combinations of width, height, kernel_size, padding and stride

--- a/hammerblade/torch/tests/test_lenet5.py
+++ b/hammerblade/torch/tests/test_lenet5.py
@@ -102,7 +102,7 @@ def test(net, loader, loss_func, hb=False):
         test_loss, num_correct, len(loader.dataset), test_accuracy
     ))
 
-@pytest.mark.skipif(torch.hb_emul_on, reason="Slow on cosim")
+@pytest.mark.skipif(not torch.hb_emul_on, reason="Slow on cosim")
 def test_lenet5_backprop_1():
     # Create a model on CPU with random weights
     net = LeNet5()

--- a/hammerblade/torch/tests/test_mlp_mnist.py
+++ b/hammerblade/torch/tests/test_mlp_mnist.py
@@ -38,7 +38,7 @@ class MLPModel(nn.Module):
 # Forward pass
 # -------------------------------------------------------------------------
 
-@pytest.mark.skipif(torch.hb_emul_on, reason="Slow on cosim")
+@pytest.mark.skipif(not torch.hb_emul_on, reason="Slow on cosim")
 def test_mlp_inference():
     # create CPU model with random parameters
     model_cpu = MLPModel()
@@ -69,7 +69,7 @@ def test_mlp_inference():
 # Backward pass
 # -------------------------------------------------------------------------
 
-@pytest.mark.skipif(torch.hb_emul_on, reason="Slow on cosim")
+@pytest.mark.skipif(not torch.hb_emul_on, reason="Slow on cosim")
 def test_mlp_backprop():
     # create CPU model with random parameters
     model_cpu = MLPModel()


### PR DESCRIPTION
- Separated HBTensor's implementation to HBTensorImpl class, so that HBTensor can be partially specialized without code duplication.
- HBTensor is now a derived class of HBTensorImpl
- HBTensor is partially specialized with `dims` parameter, and using this, strides are cached on scratchpad.
- Following are the speed ups observed on an 8x8 micro-benchmark:
   - Conv2d: 1.24x
   - Addmm: 1.8x
- Fixed a bug in pytest skipif