### PR TITLE
Updated changed cosim target

### DIFF
--- a/setup_cosim_build_env.sh
+++ b/setup_cosim_build_env.sh
@@ -44,8 +44,8 @@ else
 fi
 
 # Build COSIM runtime library and simulation executable
-make -C $BRG_BSG_BLADERUNNER_DIR/bsg_replicant/testbenches/pytorch test_loader
-make -C $BRG_BSG_BLADERUNNER_DIR/bsg_replicant/testbenches/pytorch test_loader.debug
+make -C $BRG_BSG_BLADERUNNER_DIR/bsg_replicant/testbenches/pytorch test_pytorch.log
+make -C $BRG_BSG_BLADERUNNER_DIR/bsg_replicant/testbenches/pytorch test_pytorch.debug.log
 
 # For backward compatibility.
 # Remove this with bsg_bladerunner's next version. Current is v4.0.0.


### PR DESCRIPTION
The target to build sim executables changed in bsg_replicant. This pr updates the setup cosim script to just run a small testcase to build sim executables -- the interface for which is apparently more stable.