### PR TITLE
Include $(BSG_F1_DIR)/machine.mk

### DIFF
--- a/aten/src/ATen/function_wrapper.py
+++ b/aten/src/ATen/function_wrapper.py
@@ -734,7 +734,6 @@ FunctionOption = TypedDict('FunctionOption', {
     'variants': str,
     'when_spares_dispatch': str,
     'when_sparse_dispatch': str,
-    'with_gil': bool,
     'zero_dim_dispatch_when_scalar': str,
     'redispatch_condition' : str,
     'tensor_boxing' : str,

--- a/hammerblade/torch/riscv.mk
+++ b/hammerblade/torch/riscv.mk
@@ -1,6 +1,7 @@
 .DEFAULT = help
 
 BSG_MANYCORE_DIR := $(BRG_BSG_BLADERUNNER_DIR)/bsg_manycore
+BSG_F1_DIR       := $(BRG_BSG_BLADERUNNER_DIR)/bsg_replicant
 COSIM_PYTHON_DIR := $(BRG_BSG_BLADERUNNER_DIR)/bsg_replicant/testbenches/python
 KERNEL_DIR       := $(shell git rev-parse --show-toplevel)/hammerblade/torch/kernel
 SCRIPT_DIR       := $(shell git rev-parse --show-toplevel)/hammerblade/torch/
@@ -54,6 +55,7 @@ ifeq ($(DEBUG),1)
 endif
 
 # Include BSG Manycore's builddefs
+include $(BSG_F1_DIR)/machine.mk
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master
 
 INCS := -I$(KERNEL_DIR)


### PR DESCRIPTION
Include $(BSG_F1_DIR)/machine.mk in riscv.mk so we can get the correct machine dimensions.