### PR TITLE
Clang support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,18 +7,41 @@ This work aims to port PyTorch to HammerBlade.
 
 ### How to build PyTorch to use COSIM
   This assumes that you have a working COSIM installed. Then you can either put `hb-pytorch` under `bsg_bladerunner`, or set `BRG_BSG_BLADERUNNER_DIR` to your `bladerunner` path.
- - Clone hb-pytorch repo
-    `git clone -b hb-device git@github.com:cornell-brg/hb-pytorch.git`
- - Create python virtual environment
-    `python3.6 -m venv ./venv_pytorch`
- - Install dependencies
-    `pip install numpy pyyaml mkl mkl-include setuptools cmake cffi typing sklearn tqdm pytest ninja hypothesis`
- - Init pytorch third party dependencies
-    `git submodule update --init --recursive`
- - Setup building environment variables.
-    `cd hb-pytorch && source setup_cosim_build_env.sh`
- - Build pytorch. This step can take up to 15 minutes
-    `python setup.py develop`
+ - Enable devtoolset-8 or any toolchain that supports C++14.
+ - Set following variable to point to `bsg_bladerunner` clone:
+ ```
+ export BRG_BSG_BLADERUNNER_DIR=<path to bsg_bladerunner that has be setup>
+ ```
+ - Clone hb-pytorch repo:
+ ```
+ git clone -b hb-device git@github.com:cornell-brg/hb-pytorch.git
+ ```
+ - Create python virtual environment:
+ ```
+ python3.6 -m venv ./venv_pytorch`
+ ```
+ - Install dependencies:
+ ```
+ pip install numpy pyyaml mkl mkl-include setuptools cmake cffi typing sklearn tqdm pytest ninja hypothesis
+ ```
+ - Init pytorch third party dependencies:
+ ```
+ git submodule update --init --recursive
+ ```
+ - Setup building environment variables:
+ ```
+ cd hb-pytorch && source setup_cosim_build_env.sh
+ ```
+ - Build pytorch. This step can take up to 15 minutes:
+ ```
+ python setup.py develop
+ ```
+
+ Above command also compiles device kernels with RISCV toolchain and installs the kernel binary. Optionally,
+ kernels can be compiled with Clang by running the following instead of above:
+ ```
+ CLANG=1 python setup.py develop 
+ ```
  - PyTorch can be used with cosim by running one of the following the executable in place of `python`:
     - `pycosim`: Runs python with cosim backend
     - `pycosim.trace`: Enables device instruction trace

--- a/c10/hammerblade/CMakeLists.txt
+++ b/c10/hammerblade/CMakeLists.txt
@@ -70,7 +70,7 @@ else()
   add_custom_target(
     kernel_riscv_exe
     COMMAND mkdir -p riscv
-    COMMAND make -C riscv -f $ENV{HB_KERNEL_DIR}/riscv.mk kernel.riscv
+    COMMAND make -C riscv -f $ENV{HB_KERNEL_DIR}/riscv.mk kernel.riscv -j8
     COMMAND cp riscv/kernel.riscv .
     COMMAND rm -rf riscv
     DEPENDS $ENV{HB_KERNEL_DIR}/riscv.mk

--- a/hammerblade/torch/riscv.mk
+++ b/hammerblade/torch/riscv.mk
@@ -55,6 +55,11 @@ ifeq ($(DEBUG),1)
 endif
 
 # Include BSG Manycore's builddefs
+ifdef CLANG
+export CLANG=1
+RISCV_GXX_EXTRA_OPTS += -Wno-c++11-narrowing # Fixme: fix these warnings!
+RISCV_LINK_OPTS += -lstdc++
+endif
 include $(BSG_F1_DIR)/machine.mk
 include $(BSG_MANYCORE_DIR)/software/mk/Makefile.master
 


### PR DESCRIPTION
Past few days I've been working on supporting non-blocking loads with LLVM. Initial results are very promising. This adds support for kernel compilation with Clang using related updates in bsg_manycore builddefs.

When installing hb-pytorch for cosim, kernels can be chosen to be compiled with Clang by:
```
$ CLANG=1 python setup.py develop
```