### PR TITLE
log and exp_ kernels

### DIFF
--- a/aten/src/ATen/native/hammerblade/Log.cpp
+++ b/aten/src/ATen/native/hammerblade/Log.cpp
@@ -1,0 +1,20 @@
+#include <ATen/Dispatch.h>
+#include <ATen/hammerblade/HammerBladeContext.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/UnaryOps.h>
+#include <ATen/native/hammerblade/Offload.h>
+
+namespace at { namespace native {
+namespace {
+
+static void log_kernel_hb(TensorIterator& iter) {
+    AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "log_hb", [&]() {
+        offload_op_unary(iter, "tensorlib_log");
+        });
+}
+
+} // anonymous namespace
+
+REGISTER_HAMMERBLADE_DISPATCH(log_stub, &log_kernel_hb);
+
+}} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1132,6 +1132,7 @@
   dispatch:
     CPU: _exp__cpu
     CUDA: _exp__cuda
+    HammerBlade: _exp__hb
 
 - func: exp.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
@@ -1525,6 +1526,7 @@
   dispatch:
     CPU: log_out
     CUDA: log_out
+    HammerBlade: log_out
 
 - func: log10(Tensor self) -> Tensor
   use_c10_dispatcher: full

--- a/hammerblade/torch/kernel/kernel_log.cpp
+++ b/hammerblade/torch/kernel/kernel_log.cpp
@@ -1,0 +1,31 @@
+//====================================================================
+// log kernel
+// 06/16/2020 Lin Cheng (lc873@cornell.edu)
+//====================================================================
+
+#include <kernel_common.hpp>
+#include <cmath>
+
+extern "C" {
+
+  __attribute__ ((noinline))  int tensorlib_log(
+          hb_tensor_t* t0_p,
+          hb_tensor_t* t1_p) {
+    auto res = HBTensor<float>(t0_p);
+    auto input = HBTensor<float>(t1_p);
+    // Start profiling
+    bsg_cuda_print_stat_kernel_start();
+    hb_tiled_foreach(res, input,
+      [&](float a) {
+        return std::log(a);
+    });
+    //   End profiling
+    bsg_cuda_print_stat_kernel_end();
+
+    g_barrier.sync();
+    return 0;
+  }
+
+  HB_EMUL_REG_KERNEL(tensorlib_log, hb_tensor_t*, hb_tensor_t*)
+
+}

--- a/hammerblade/torch/tests/test_BinaryCrossEntropyWithLogits.py
+++ b/hammerblade/torch/tests/test_BinaryCrossEntropyWithLogits.py
@@ -1,0 +1,28 @@
+"""
+Unit tests for torch.nn.F.binary_cross_entropy_with_logits
+06/16/2020 Lin Cheng (lc873@cornell.edu)
+"""
+
+import torch
+import torch.nn.functional as F
+import random
+import hbutils
+
+torch.manual_seed(42)
+random.seed(42)
+
+def test_torch_nn_F_BinaryCrossEntropyWithLogits_1():
+    input = torch.randn(3, requires_grad=True)
+    input_h = hbutils.init_hb_tensor(input)
+    assert input_h is not input
+    target = torch.empty(3).random_(2)
+    output = F.binary_cross_entropy_with_logits(input, target)
+    output_h = F.binary_cross_entropy_with_logits(input_h, target.hammerblade())
+    assert output_h.device == torch.device("hammerblade")
+    assert torch.allclose(output, output_h.cpu())
+    output.backward()
+    output_h.backward()
+    assert input.grad is not None
+    assert input_h.grad is not None
+    assert input.grad is not input_h.grad
+    assert torch.allclose(input.grad, input_h.grad.cpu())

--- a/hammerblade/torch/tests/test_exp.py
+++ b/hammerblade/torch/tests/test_exp.py
@@ -3,8 +3,10 @@ Tests for exp
 04/13/2020 Yuyi He (yh383@cornell.edu)
 """
 import torch
+import random
 
 torch.manual_seed(42)
+random.seed(42)
 
 def _test_torch_exp(x):
     h = x.hammerblade()
@@ -26,5 +28,5 @@ def test_torch_exp_3():
     _test_torch_exp(x)
 
 def test_torch_exp_4():
-    x = torch.Tensor([float('inf')]) 
+    x = torch.Tensor([float('inf')])
     _test_torch_exp(x)

--- a/hammerblade/torch/tests/test_log.py
+++ b/hammerblade/torch/tests/test_log.py
@@ -1,0 +1,36 @@
+"""
+Tests for log
+06/16/2020 Lin Cheng (lc873@cornell.edu)
+"""
+import torch
+import random
+from hypothesis import given, settings
+from .hypothesis_test_util import HypothesisUtil as hu
+
+torch.manual_seed(42)
+random.seed(42)
+
+def _test_torch_log(x):
+    h = x.hammerblade()
+    log_x = x.log()
+    log_h = h.log()
+    assert log_h.device == torch.device("hammerblade")
+    assert torch.allclose(log_h.cpu(), log_x, equal_nan=True)
+
+def test_torch_log_1():
+    x = torch.randn(3, 5)
+    _test_torch_log(x)
+
+def test_torch_log_2():
+    x = torch.ones(10)
+    _test_torch_log(x)
+
+def test_torch_log_3():
+    x = torch.zeros(5)
+    _test_torch_log(x)
+
+@settings(deadline=None)
+@given(tensor=hu.tensor())
+def test_torch_log_hypothesis(tensor):
+    x = torch.tensor(tensor)
+    _test_torch_log(x)


### PR DESCRIPTION
In this PR:
 - registered exp_ op
 - added log_out kernel
 - with these 2 kernels, we can run `BinaryCrossEntropyWithLogits` on HB