### PR TITLE
Parallel Convolution

### DIFF
--- a/hammerblade/torch/kernel/hb_spatial_for.hpp
+++ b/hammerblade/torch/kernel/hb_spatial_for.hpp
@@ -1,0 +1,33 @@
+// =========================================================
+// HB Spatial For
+// 
+// 07/19/2020 Bandhav Veluri
+// =========================================================
+
+// ---------------------------------------------------------
+// HB 2D spatial for
+// ---------------------------------------------------------
+template <class FetchFunctor>
+inline void hb_spatial_for(size_t N, size_t M, FetchFunctor functor) {
+  //---------------------------------------------------
+  // calculate x dimension start and end for this tile
+  //---------------------------------------------------
+  size_t len_per_tile = N / bsg_tiles_X + 1;
+  size_t start_x = len_per_tile * __bsg_x;
+  size_t end_x = start_x + len_per_tile;
+  end_x = (end_x > N)  ? N : end_x;
+
+  //---------------------------------------------------
+  // calculate Y dimension start and end for this tile
+  //---------------------------------------------------
+  len_per_tile = M / bsg_tiles_Y + 1;
+  size_t start_y = len_per_tile * __bsg_y;
+  size_t end_y = start_y + len_per_tile;
+  end_y = (end_y > M)  ? M : end_y;
+
+  for (size_t i = start_x; i < end_x; i++) {
+    for (size_t j = start_y; j < end_y; j++) {
+      functor(i, j);
+    }
+  }
+}

--- a/hammerblade/torch/kernel/hb_tiled_for.hpp
+++ b/hammerblade/torch/kernel/hb_tiled_for.hpp
@@ -372,55 +372,69 @@ inline void hb_tiled_for(size_t numel, FetchFunctor functor) {
   }
 }
 
-template <class FetchFunctor, typename... T>
-inline void hb_tiled_for(FetchFunctor functor, T... numels_) {
+template <class FetchFunctor>
+inline void hb_tiled_for(FetchFunctor functor,
+                         size_t N, size_t M) {
   //--------------------------------------
   // calculate start and end for this tile
   //--------------------------------------
   hb_range range;
-  calc_range(&range, numel);
+  calc_range(&range, N * M);
   size_t start = range.start;
   size_t end   = range.end;
 
   //-----------------
   // loop
   //----------------
-  size_t numels[] = {numels_...};
-  size_t nargs = sizeof(numels) / sizeof(numels[0]);
-  size_t total_numel = 0;
-  UNROLL(4) for(size_t i = 0; i < nargs; ++i) {
-    total_numel *= numels[i];
-  }
-
   for (size_t i = start; i < end; i++) {
-    switch(nargs) {
-      case 2: {
-        size_t a = (i / numels[1]) % numels[0];
-        size_t b = i % numels[1];
-        functor(a, b);
-        break;
-      }
-      
-      case 3: {
-        size_t a = (i / (numels[1] * numels[2]) % numels[0];
-        size_t b = (i / numels[2]) % numels[1];
-        size_t c = i % numels[2];
-        functor(a, b, c);
-        break;
-      }
+    size_t b = (i / M) % N;
+    size_t a = i % M;
+    functor(b, a);
+  }
+}
 
-      case 4: {
-        size_t a = (i / (numels[1] * numels[2] * numels[3]) % numels[0];
-        size_t b = (i / (numels[2] * numels[3]) % numels[1];
-        size_t c = (i / numels[3]) % numels[2];
-        size_t d = i % numels[3];
-        functor(a, b, c, d);
-        break;
-      }
+template <class FetchFunctor>
+inline void hb_tiled_for(FetchFunctor functor,
+                        size_t O, size_t N, size_t M) {
+  //--------------------------------------
+  // calculate start and end for this tile
+  //--------------------------------------
+  hb_range range;
+  calc_range(&range, O * N * M);
+  size_t start = range.start;
+  size_t end   = range.end;
 
-      default:
-        functor(i);
-    }
+  //-----------------
+  // loop
+  //----------------
+  for (size_t i = start; i < end; i++) {
+    size_t c = (i / (N * M)) % O;
+    size_t b = (i / M) % N;
+    size_t a = i % M;
+    functor(c, b, a);
+  }
+}
+
+template <class FetchFunctor>
+inline void hb_tiled_for(FetchFunctor functor,
+                        size_t P, size_t O, size_t N, size_t M) {
+  //--------------------------------------
+  // calculate start and end for this tile
+  //--------------------------------------
+  hb_range range;
+  calc_range(&range, P * O * N * M);
+  size_t start = range.start;
+  size_t end   = range.end;
+
+  //-----------------
+  // loop
+  //----------------
+  for (size_t i = start; i < end; i++) {
+    size_t d = (i / (O * N * M)) % P;
+    size_t c = (i / (N * M)) % O;
+    size_t b = (i / M) % N;
+    size_t a = i % M;
+    functor(d, c, b, a);
   }
 }
 

--- a/hammerblade/torch/kernel/hb_tiled_for.hpp
+++ b/hammerblade/torch/kernel/hb_tiled_for.hpp
@@ -372,6 +372,58 @@ inline void hb_tiled_for(size_t numel, FetchFunctor functor) {
   }
 }
 
+template <class FetchFunctor, typename... T>
+inline void hb_tiled_for(FetchFunctor functor, T... numels_) {
+  //--------------------------------------
+  // calculate start and end for this tile
+  //--------------------------------------
+  hb_range range;
+  calc_range(&range, numel);
+  size_t start = range.start;
+  size_t end   = range.end;
+
+  //-----------------
+  // loop
+  //----------------
+  size_t numels[] = {numels_...};
+  size_t nargs = sizeof(numels) / sizeof(numels[0]);
+  size_t total_numel = 0;
+  UNROLL(4) for(size_t i = 0; i < nargs; ++i) {
+    total_numel *= numels[i];
+  }
+
+  for (size_t i = start; i < end; i++) {
+    switch(nargs) {
+      case 2: {
+        size_t a = (i / numels[1]) % numels[0];
+        size_t b = i % numels[1];
+        functor(a, b);
+        break;
+      }
+      
+      case 3: {
+        size_t a = (i / (numels[1] * numels[2]) % numels[0];
+        size_t b = (i / numels[2]) % numels[1];
+        size_t c = i % numels[2];
+        functor(a, b, c);
+        break;
+      }
+
+      case 4: {
+        size_t a = (i / (numels[1] * numels[2] * numels[3]) % numels[0];
+        size_t b = (i / (numels[2] * numels[3]) % numels[1];
+        size_t c = (i / numels[3]) % numels[2];
+        size_t d = i % numels[3];
+        functor(a, b, c, d);
+        break;
+      }
+
+      default:
+        functor(i);
+    }
+  }
+}
+
 // =========================================================
 // HB tile range
 // =========================================================

--- a/hammerblade/torch/kernel/kernel_common.hpp
+++ b/hammerblade/torch/kernel/kernel_common.hpp
@@ -27,6 +27,7 @@
 #include "hb_tensor.hpp"
 #include <hb_assert.hpp>
 #include <hb_tiled_for.hpp>
+#include <hb_spatial_for.hpp>
 #include <hb_common.hpp>
 
 __remote void* hb_memcpy(__remote void* NOALIAS dest,

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -39,9 +39,9 @@ extern "C" {
 
     // Start profiling
     bsg_cuda_print_stat_kernel_start();
-
-    hb_tiled_for([&](size_t n, size_t co, size_t yh, size_t yw) {
-      for(uint32_t ci = 0; ci < Cin; ++ci) {
+      
+    for(uint32_t ci = 0; ci < Cin; ++ci) // input channel first to maximum data reuse
+      hb_tiled_for([&](size_t n, size_t co, size_t yh, size_t yw) {
         for(uint32_t kh = 0; kh < Kh; ++kh) {
           for(uint32_t kw = 0; kw < Kw; ++kw) {
             if((ci + kh + kw) == 0) {
@@ -56,8 +56,7 @@ extern "C" {
             } // else 0
           }
         }
-      }
-    }, N, Cout, Hout, Wout);
+      }, N, Cout, Hout, Wout);
 
     // End profiling
     bsg_cuda_print_stat_kernel_end();

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -134,14 +134,7 @@ extern "C" {
     bsg_cuda_print_stat_kernel_start();
 
     // init input grads
-    hb_tiled_for(N * Cin * Hin * Win, [&](size_t i) {
-        uint32_t xw = i % Win;
-        uint32_t xh = (i / Win) % Hin;
-        uint32_t ci = (i / (Hin * Win)) % Cin;
-        uint32_t n  = (i / (Cin * Hin * Win)) % N;
-
-        x(n, ci, xh, xw) = 0.0;
-    });
+    hb_tiled_foreach([]() {return 0.0;}, x);
     g_barrier.sync();
 
 

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -235,17 +235,16 @@ extern "C" {
     // Start profiling
     bsg_cuda_print_stat_kernel_start();
 
-    if(__bsg_id == 0) {
+    hb_tiled_for(Cout, [&](size_t co) {
       for(uint32_t n = 0; n < N; ++n)
-        for(uint32_t co = 0; co < Cout; ++co)
-          for(uint32_t yh = 0; yh < Hout; ++yh)
-            for(uint32_t yw = 0; yw < Wout; ++yw) {
-              if((n + yh + yw) == 0)
-                gb(co) = 0.0f;
+        for(uint32_t yh = 0; yh < Hout; ++yh)
+          for(uint32_t yw = 0; yw < Wout; ++yw) {
+            if((n + yh + yw) == 0)
+              gb(co) = 0.0f;
 
-              gb(co) += y(n, co, yh, yw);
-            }
-    }
+            gb(co) += y(n, co, yh, yw);
+          }
+    });
 
     // End profiling
     bsg_cuda_print_stat_kernel_end();

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -139,7 +139,7 @@ extern "C" {
 
     hb_tiled_for(N * Cin, [&](size_t i) {
         uint32_t ci = i % Cin;
-        uint32_t n  = (i / Cin) % n;
+        uint32_t n  = (i / Cin) % N;
 
         for(uint32_t co = 0; co < Cout; ++co)
           for(uint32_t yh = 0; yh < Hout; ++yh)
@@ -196,27 +196,23 @@ extern "C" {
     hb_tiled_foreach([]() {return 0.0;}, w);
     g_barrier.sync();
 
-    // Preliminary single tile implementation
-    //
-    // Grows O(^5) with image size:
-    //   N x Cout x Cin x H x W
-    //   Kernel loops are constant-time
-    if(__bsg_id == 0) {
-      for(uint32_t n = 0; n < N; ++n)
-        for(uint32_t co = 0; co < Cout; ++co)
+    hb_tiled_for(Cout * Cin, [&](size_t i) {
+        uint32_t ci = i % Cin;
+        uint32_t co  = (i / Cin) % Cout;
+
+        for(uint32_t n = 0; n < N; ++n)
           for(uint32_t yh = 0; yh < Hout; ++yh)
             for(uint32_t yw = 0; yw < Wout; ++yw)
-              for(uint32_t ci = 0; ci < Cin; ++ci)
-                for(uint32_t kh = 0; kh < Kh; ++kh)
-                  for(uint32_t kw = 0; kw < Kw; ++kw) {
-                    int32_t xh = Sh * yh - Ph + kh;
-                    int32_t xw = Sw * yw - Pw + kw;
+              for(uint32_t kh = 0; kh < Kh; ++kh)
+                for(uint32_t kw = 0; kw < Kw; ++kw) {
+                  int32_t xh = Sh * yh - Ph + kh;
+                  int32_t xw = Sw * yw - Pw + kw;
 
-                    if(xh >= 0 && xh < Hin && xw >= 0 && xw < Win) {
-                      w(co, ci, kh, kw) += y(n, co, yh, yw) * x(n, ci, xh, xw);
-                    } // else 0
-                  }
-    }
+                  if(xh >= 0 && xh < Hin && xw >= 0 && xw < Win) {
+                    w(co, ci, kh, kw) += y(n, co, yh, yw) * x(n, ci, xh, xw);
+                  } // else 0
+                }
+    });
 
     // End profiling
     bsg_cuda_print_stat_kernel_end();


### PR DESCRIPTION
- Parallel forward and backward convolutions:
  - Forward: output tensor is distributed among tiles.
  - Backward:
     - Input gradients: batches and input channels are distributed among tiles.
     - Weight gradients: Input and output channels are distribute among tiles.
  - Also includes a couple scheduling optimizations.
  - ~90x speedup on ResNet workload on the chip.
- Added multi-indexed-tiled-for (`hb_tiled_for(<lambda>, index1, index2, ...)`) to simplify loop scheduling optimizations. This also eliminates the need to manually compute indices by `/` and `%` on monolithic index.
- Added `hb_spatial_for` utility function to be able to do 2D spatial distribution among tiles, as opposed to distributing single monolithic index among tiles. I had found this useful when I experimented it on addmm (https://github.com/cornell-brg/hb-pytorch/issues/121), so tried this on Conv2d as well. It turns out that images dimensions are not large enough to make full use of manycore array for Conv2d. But we should definitely try this on addmm.

Merge after #135 