### PR TITLE
Install disassembly with pytorch build

### DIFF
--- a/c10/hammerblade/CMakeLists.txt
+++ b/c10/hammerblade/CMakeLists.txt
@@ -75,12 +75,12 @@ else()
   # Kernel binary
   add_custom_target(
     kernel_riscv_exe
+    COMMAND rm -rf riscv
     COMMAND mkdir -p riscv
     COMMAND make -C riscv -f $ENV{HB_KERNEL_DIR}/riscv.mk ${KERNEL_MAKE_FLAGS} kernel.riscv -j8
-    COMMAND cp riscv/kernel.riscv .
-    COMMAND rm -rf riscv
+    COMMAND make -C riscv -f $ENV{HB_KERNEL_DIR}/riscv.mk ${KERNEL_MAKE_FLAGS} all.dis -j8
     DEPENDS $ENV{HB_KERNEL_DIR}/riscv.mk
-    BYPRODUCTS kernel.riscv
+    BYPRODUCTS riscv/
     )
 
   add_dependencies(c10_hammerblade kernel_riscv_exe)
@@ -120,8 +120,11 @@ endforeach()
 install(FILES ${CMAKE_BINARY_DIR}/c10/hammerblade/impl/hammerblade_cmake_macros.h
   DESTINATION include/c10/hammerblade/impl)
 
+file(GLOB KERNEL_FILES ${CMAKE_CURRENT_BINARY_DIR}/riscv/kernel.riscv
+                       ${CMAKE_CURRENT_BINARY_DIR}/riscv/*.dis)
+
 if(NOT USE_HB_EMUL)
-  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/kernel.riscv DESTINATION riscv)
+  install(FILES ${KERNEL_FILES} DESTINATION riscv)
   install(PROGRAMS $ENV{HB_KERNEL_DIR}/pycosim.sh
           DESTINATION bin RENAME pycosim)
   install(PROGRAMS $ENV{HB_KERNEL_DIR}/pycosim.trace.sh

--- a/hammerblade/torch/riscv.mk
+++ b/hammerblade/torch/riscv.mk
@@ -81,6 +81,8 @@ KERNEL_CSRCS   := $(notdir $(wildcard $(KERNEL_DIR)/*.c))
 KERNEL_CPPSRCS := $(notdir $(wildcard $(KERNEL_DIR)/*.cpp))
 KERNEL_OBJS    := $(patsubst %.c,%.o,$(KERNEL_CSRCS)) \
                   $(patsubst %.cpp,%.o,$(KERNEL_CPPSRCS))
+KERNEL_DIS     := $(patsubst %.c,%.dis,$(KERNEL_CSRCS)) \
+                  $(patsubst %.cpp,%.dis,$(KERNEL_CPPSRCS))
 
 $(KERNEL_CSRCS): %.c : $(KERNEL_DIR)/%.c
 	cp $^ $@
@@ -94,8 +96,13 @@ kernel.riscv: $(KERNEL_OBJS)
 	$(RISCV_LINK) $(KERNEL_OBJS) $(SPMD_COMMON_OBJECTS) \
 		-L. -l:$(BSG_MANYCORE_LIB) -o $@ $(filter-out -nostdlib,$(RISCV_LINK_OPTS))
 
-%.dis: %.o
-	$(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-objdump -M numeric --disassemble-all -S $<
+$(KERNEL_DIS): %.dis: %.o
+	$(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-objdump -M numeric --disassemble-all -S $< > $@
+
+kernel.dis: kernel.riscv
+	$(RISCV_BIN_DIR)/riscv32-unknown-elf-dramfs-objdump -M numeric --disassemble-all -S $< > $@
+
+all.dis: kernel.dis $(KERNEL_DIS)
 
 clean:
 	-rm -rf stack.info.* *.log *.csv ucli.key


### PR DESCRIPTION
Builds and installs disassembly files along with kernel binary. This makes opening disassembly very convenient, with the added benefit of making sure we are running and looking at the exact same version of machine code.