### PR TITLE
[setup_cosim] adjust setup_cosim script so we can share COSIM install…

### DIFF
--- a/setup_cosim_build_env.sh
+++ b/setup_cosim_build_env.sh
@@ -43,10 +43,14 @@ else
   export BSG_MANYCORE_LDPATH=$BRG_BSG_BLADERUNNER_DIR/bsg_replicant/libraries/platforms/aws-vcs
 fi
 
-# Build COSIM runtime library and simulation executable
-export BSG_MACHINE=4x4_fast_n_fake
-export BSG_MACHINE_PATH=$BRG_BSG_BLADERUNNER_DIR/bsg_replicant/machines/$BSG_MACHINE
-make -C $BRG_BSG_BLADERUNNER_DIR/bsg_replicant/examples/python test_python.log
+# Build COSIM runtime library and simulation executable if not using one of the
+# BRG servers -- on BRG servers we have global installed COSIM so SW side ppl
+# dont have to worry about COSIM installation
+if [[ "x${SETUP_BRG_HAMMERBLADE}" != "xyes" ]]; then
+  export BSG_MACHINE=4x4_fast_n_fake
+  export BSG_MACHINE_PATH=$BRG_BSG_BLADERUNNER_DIR/bsg_replicant/machines/$BSG_MACHINE
+  make -C $BRG_BSG_BLADERUNNER_DIR/bsg_replicant/examples/python test_python.log
+fi
 
 export HB_KERNEL_DIR=$DIR/hammerblade/torch
 


### PR DESCRIPTION
 - Don't rebuild python test_loader if running on one of the BRG servers -- we share a single global installation of COSIM. `BSG_MACHINE` and `BSG_MACHINE_PATH` will be defined in `setup-hb.sh` which should be sourced when using BRG servers.
 - Bump fbgemm version so it wont keep showing up ...
