### PR TITLE
enable/disable bladerunner trace/log from python

### DIFF
--- a/c10/hammerblade/HammerBladeDevice.cpp
+++ b/c10/hammerblade/HammerBladeDevice.cpp
@@ -8,4 +8,6 @@ hb_mc_device_t _hb_device;
 hb_mc_dimension_t _hb_tg_dim = { .x = 1, .y = 1};
 hb_mc_dimension_t _hb_grid_dim = { .x = 1, .y = 1};
 
+bool hb_mc_should_trace = false;
+
 }} // namespace c10::hammerblade

--- a/c10/hammerblade/HammerBladeDevice.h
+++ b/c10/hammerblade/HammerBladeDevice.h
@@ -16,6 +16,8 @@ extern hb_mc_dimension_t _hb_tg_dim;
 extern hb_mc_dimension_t _hb_grid_dim;
 extern hb_mc_device_t _hb_device;
 
+extern bool hb_mc_should_trace;
+
 #define PATH(x) pstr(x)
 #define pstr(x) #x
 static char _bin_path[] = PATH(HB_KERNEL_PATH); // path to device kernel binary

--- a/c10/hammerblade/HammerBladeFunctions.cpp
+++ b/c10/hammerblade/HammerBladeFunctions.cpp
@@ -181,7 +181,23 @@ void offload_kernel(const char* kernel, std::vector<eva_t> args) {
   C10_HB_CHECK(hb_mc_kernel_enqueue(&_hb_device, _hb_grid_dim, _hb_tg_dim, kernel,
                                     args.size(), cuda_argv));
 
+  // ----------------------------------------------
+  // Start the tracer (vanilla_operation_trace.csv)
+  // ----------------------------------------------
+  C10_HB_CHECK(hb_mc_manycore_trace_enable((&_hb_device)->mc));
+
+  // ----------------------------------------------
+  // Start the logger (vanilla.log)
+  // ----------------------------------------------
+  C10_HB_CHECK(hb_mc_manycore_log_enable((&_hb_device)->mc));
+
   C10_HB_CHECK(hb_mc_device_tile_groups_execute(&_hb_device));
+
+  // ----------------------------------------------
+  // Disable the tracer and the logger
+  // ----------------------------------------------
+  C10_HB_CHECK(hb_mc_manycore_log_disable((&_hb_device)->mc));
+  C10_HB_CHECK(hb_mc_manycore_trace_disable((&_hb_device)->mc));
 
   // write the SIMULATED time to ExecutionTime log
   // set to 0 for now since bsg_time is ... wired

--- a/c10/hammerblade/HammerBladeFunctions.cpp
+++ b/c10/hammerblade/HammerBladeFunctions.cpp
@@ -182,6 +182,7 @@ void offload_kernel(const char* kernel, std::vector<eva_t> args) {
                                     args.size(), cuda_argv));
 
   if (hb_mc_should_trace) {
+    std::cout << "tracing " << kernel << " ... ";
     // ----------------------------------------------
     // Start the tracer (vanilla_operation_trace.csv)
     // ----------------------------------------------
@@ -196,6 +197,7 @@ void offload_kernel(const char* kernel, std::vector<eva_t> args) {
   C10_HB_CHECK(hb_mc_device_tile_groups_execute(&_hb_device));
 
   if (hb_mc_should_trace) {
+    std::cout << "done!" << std::endl;
     // ----------------------------------------------
     // Disable the tracer and the logger
     // ----------------------------------------------

--- a/c10/hammerblade/HammerBladeFunctions.h
+++ b/c10/hammerblade/HammerBladeFunctions.h
@@ -41,6 +41,8 @@ C10_HAMMERBLADE_API void* memcpy_device_to_host(void *dst, const void *src, uint
 C10_HAMMERBLADE_API void* DMA_host_to_device(void *dst, const void *src, uint32_t nbytes);
 C10_HAMMERBLADE_API void* DMA_device_to_host(void *dst, const void *src, uint32_t nbytes);
 C10_HAMMERBLADE_API void offload_kernel(const char* kernel, std::vector<eva_t> args);
+C10_HAMMERBLADE_API void enable_hb_trace();
+C10_HAMMERBLADE_API void disable_hb_trace();
 
 extern std::atomic<int> hb_device_status;
 

--- a/c10/hammerblade/HammerBladeFunctions.h
+++ b/c10/hammerblade/HammerBladeFunctions.h
@@ -17,6 +17,7 @@
 /*
  * inlcude bsg_manycore.h here
  */
+#include <bsg_manycore.h>
 #include <bsg_manycore_cuda.h>
 #include <bsg_manycore_printing.h>
 

--- a/c10/hammerblade/emul/bsg_manycore.cpp
+++ b/c10/hammerblade/emul/bsg_manycore.cpp
@@ -1,4 +1,5 @@
 #include <bsg_manycore.h>
+#include <bsg_manycore_errno.h>
 
 #ifdef __cplusplus
 extern "C"{
@@ -10,6 +11,22 @@ int bsg_printf(const char *fmt, ...) {
   vfprintf(stderr, fmt, argptr);
   va_end(argptr);
   return 0;
+}
+
+int hb_mc_manycore_trace_enable(hb_mc_manycore_t *mc) {
+  return HB_MC_SUCCESS;
+}
+
+int hb_mc_manycore_trace_disable(hb_mc_manycore_t *mc) {
+  return HB_MC_SUCCESS;
+}
+
+int hb_mc_manycore_log_enable(hb_mc_manycore_t *mc) {
+  return HB_MC_SUCCESS;
+}
+
+int hb_mc_manycore_log_disable(hb_mc_manycore_t *mc) {
+  return HB_MC_SUCCESS;
 }
 
 #ifdef __cplusplus

--- a/c10/hammerblade/emul/bsg_manycore.h
+++ b/c10/hammerblade/emul/bsg_manycore.h
@@ -16,7 +16,7 @@ int bsg_printf(const char *fmt, ...);
 
 typedef struct hb_mc_manycore {
         const char *name;      //!< the name of this manycore
-        hb_mc_config_t config; //!< configuration of the manycore
+        // hb_mc_config_t config; //!< configuration of the manycore
         void *platform;        //!< machine-specific data pointer
         int dram_enabled;      //!< operating in no-dram mode?
 } hb_mc_manycore_t;

--- a/c10/hammerblade/emul/bsg_manycore.h
+++ b/c10/hammerblade/emul/bsg_manycore.h
@@ -14,6 +14,42 @@ extern "C"{
 
 int bsg_printf(const char *fmt, ...);
 
+typedef struct hb_mc_manycore {
+        const char *name;      //!< the name of this manycore
+        hb_mc_config_t config; //!< configuration of the manycore
+        void *platform;        //!< machine-specific data pointer
+        int dram_enabled;      //!< operating in no-dram mode?
+} hb_mc_manycore_t;
+
+/**
+ * Enable trace file generation (vanilla_operation_trace.csv)
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_trace_enable(hb_mc_manycore_t *mc);
+
+/**
+ * Disable trace file generation (vanilla_operation_trace.csv)
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_trace_disable(hb_mc_manycore_t *mc);
+
+/**
+ * Enable log file generation (vanilla.log)
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_log_enable(hb_mc_manycore_t *mc);
+
+/**
+ * Disable log file generation (vanilla.log)
+ * @param[in] mc    A manycore instance initialized with hb_mc_manycore_init()
+ * @return HB_MC_SUCCESS on success. Otherwise an error code defined in bsg_manycore_errno.h.
+ */
+int hb_mc_manycore_log_disable(hb_mc_manycore_t *mc);
+
+
 #ifdef __cplusplus
 }
 #endif
@@ -53,6 +89,7 @@ static inline void bsg_cuda_print_stat_start(uint32_t tag) {
 static inline void bsg_cuda_print_stat_end(uint32_t tag) {
   return;
 }
+
 
 #define bsg_fail() assert (1==0 /* bsg_fail is called */)
 

--- a/c10/hammerblade/emul/bsg_manycore_cuda.h
+++ b/c10/hammerblade/emul/bsg_manycore_cuda.h
@@ -29,6 +29,7 @@
 #define BSG_MANYCORE_CUDA_H
 #include <bsg_manycore_features.h>
 #include <bsg_manycore_eva.h>
+#include <bsg_manycore.h>
 
 #ifdef __cplusplus
 #include <cstdint>
@@ -117,13 +118,14 @@ typedef int hb_mc_manycore_id_t;
 
 
         typedef struct {
+                hb_mc_manycore_t *mc;
                 hb_mc_program_t *program;
                 hb_mc_mesh_t *mesh;
                 hb_mc_tile_group_t *tile_groups;
                 uint32_t num_tile_groups;
                 uint32_t tile_group_capacity;
                 uint8_t num_grids;
-        } hb_mc_device_t; 
+        } hb_mc_device_t;
 
 
         enum hb_mc_memcpy_kind {

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -19,6 +19,7 @@
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include <c10/probe/HBProfiler.h>
+#include <c10/hammerblade/HammerBladeFunctions.h>
 
 #include <torch/csrc/THP.h>
 #include <torch/csrc/DynamicTypes.h>

--- a/torch/csrc/Module.cpp
+++ b/torch/csrc/Module.cpp
@@ -526,6 +526,16 @@ static PyObject * THPModule_hbProfilerEnd(PyObject *module, PyObject *noargs) {
   Py_RETURN_NONE;
 }
 
+static PyObject * THPModule_hbEnableTrace(PyObject *module, PyObject *noargs) {
+  c10::hammerblade::enable_hb_trace();
+  Py_RETURN_NONE;
+}
+
+static PyObject * THPModule_hbDisableTrace(PyObject *module, PyObject *noargs) {
+  c10::hammerblade::disable_hb_trace();
+  Py_RETURN_NONE;
+}
+
 #ifdef PROFILE_ATEN
 static PyObject * THPModule_hbProfilerExecTimeRawStack(PyObject *module, PyObject *noargs) {
   return PyUnicode_FromString(c10::probe::exec_time_raw_stack().c_str());
@@ -650,6 +660,8 @@ static PyMethodDef TorchMethods[] = {
   {"_get_qengine", (PyCFunction)THPModule_qEngine, METH_NOARGS, nullptr},
   {"_set_qengine", (PyCFunction)THPModule_setQEngine, METH_O, nullptr},
   {"_supported_qengines", (PyCFunction)THPModule_supportedQEngines, METH_NOARGS, nullptr},
+  {"hb_trace_enable", (PyCFunction)THPModule_hbEnableTrace, METH_NOARGS,  nullptr},
+  {"hb_trace_disable", (PyCFunction)THPModule_hbDisableTrace, METH_NOARGS,  nullptr},
   {"_hb_profiler_start", (PyCFunction)THPModule_hbProfilerStart, METH_NOARGS,  nullptr},
   {"_hb_profiler_end",   (PyCFunction)THPModule_hbProfilerEnd,   METH_NOARGS,  nullptr},
 #ifdef PROFILE_ATEN


### PR DESCRIPTION
In this PR:
 - emulate `hb_mc_manycore_trace_enable/disable` and `hb_mc_manycore_log_enable/disable` as NOPs.
 - added 2 python level hooks, `torch.hb_trace_enable()` and `torch.hb_trace_disable()`. When enabled, "tracing" and "logging" of bladerunner are turned on -- `vanilla_operation_trace.csv` and `vanilla.log` will be popluated.
 - tracing is enabled around kernel offloading only.