### PR TITLE
Fix: torch/riscv/ is not populated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -258,6 +258,7 @@ stats/
 *.cosim
 *.vpd
 *.riscv
+*.dis
 *.cosim.daidir/
 *.cosim.tmp/
 ucli.key

--- a/c10/hammerblade/CMakeLists.txt
+++ b/c10/hammerblade/CMakeLists.txt
@@ -124,7 +124,10 @@ file(GLOB KERNEL_FILES ${CMAKE_CURRENT_BINARY_DIR}/riscv/kernel.riscv
                        ${CMAKE_CURRENT_BINARY_DIR}/riscv/*.dis)
 
 if(NOT USE_HB_EMUL)
-  install(FILES ${KERNEL_FILES} DESTINATION riscv)
+  install(DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/riscv/
+          DESTINATION riscv
+          FILES_MATCHING PATTERN "*.dis")
+  install(FILES ${CMAKE_CURRENT_BINARY_DIR}/riscv/kernel.riscv DESTINATION riscv)
   install(PROGRAMS $ENV{HB_KERNEL_DIR}/pycosim.sh
           DESTINATION bin RENAME pycosim)
   install(PROGRAMS $ENV{HB_KERNEL_DIR}/pycosim.trace.sh


### PR DESCRIPTION
This PR fixed an issue introduced by #139 
 - Basically the problem was, `GLOB` runs before build stage, so the files we are looking for, for example, `kernel.riscv` and `tensorlib_add.dis`, are not generated yet. Thus, cmake has no idea what to install.
 - This issue is fixed by using `install(DIRECTORY` instead of `install(FILES`