### PR TITLE
Profiler bug fix

### DIFF
--- a/c10/probe/ExecutionTime.cpp
+++ b/c10/probe/ExecutionTime.cpp
@@ -66,7 +66,9 @@ ExecutionTimeLog::~ExecutionTimeLog() {
   auto delta = std::chrono::duration_cast<std::chrono::microseconds>
     (std::chrono::high_resolution_clock::now() - start);
   g_execution_time_profiler.log(stack, delta);
+#ifdef HB_REDISPATCH
   g_per_op_execution_time_profiler.log(stack, delta);
+#endif
 }
 
 }} // namespace c10::probe

--- a/c10/probe/HBProfiler.cpp
+++ b/c10/probe/HBProfiler.cpp
@@ -138,8 +138,10 @@ HBProfilerTrimLog::~HBProfilerTrimLog()
 }
 
 void HBProfilerTrimLog::trim_manual_log_exec_time(std::chrono::microseconds simulated) {
-  g_execution_time_profiler.log(g_curr_call_stack, simulated);
-  g_per_op_execution_time_profiler.log(g_curr_call_stack, simulated);
+  if (hb_profiler_is_in_roi() && hb_profiler_thread_safe()) {
+    g_execution_time_profiler.log(g_curr_call_stack, simulated);
+    g_per_op_execution_time_profiler.log(g_curr_call_stack, simulated);
+  }
 }
 
 }} // namespace c10::probe

--- a/c10/probe/HBProfiler.cpp
+++ b/c10/probe/HBProfiler.cpp
@@ -97,8 +97,10 @@ HBProfilerLog::HBProfilerLog(const std::string& func_name) {
     g_curr_call_stack.push_back(func_name);
     execution_time_log = new ExecutionTimeLog(g_curr_call_stack);
     if (hb_profiler_is_top_level()) {
-      g_per_op_execution_time_profiler.reset();
       g_execution_charter.log(func_name);
+#ifdef HB_REDISPATCH
+      g_per_op_execution_time_profiler.reset();
+#endif
     }
   }
 }
@@ -108,6 +110,7 @@ HBProfilerLog::~HBProfilerLog()
 {
   if (hb_profiler_is_in_roi() && hb_profiler_thread_safe()) {
     delete execution_time_log;
+#ifdef HB_REDISPATCH
     if (hb_profiler_is_top_level()) {
       std::string per_op_log = g_per_op_execution_time_profiler.str_dump();
       if (per_op_log.find("@CPU_LOG@") != std::string::npos) {
@@ -116,6 +119,7 @@ HBProfilerLog::~HBProfilerLog()
         std::cerr << "#TOP_LEVEL_FUNC_END#__" << g_curr_call_stack.back() << std::endl;
       }
     }
+#endif
     g_curr_call_stack.pop_back();
   }
 }
@@ -140,7 +144,9 @@ HBProfilerTrimLog::~HBProfilerTrimLog()
 void HBProfilerTrimLog::trim_manual_log_exec_time(std::chrono::microseconds simulated) {
   if (hb_profiler_is_in_roi() && hb_profiler_thread_safe()) {
     g_execution_time_profiler.log(g_curr_call_stack, simulated);
+#ifdef HB_REDISPATCH
     g_per_op_execution_time_profiler.log(g_curr_call_stack, simulated);
+#endif
   }
 }
 

--- a/hammerblade/torch/tests/test_profiling.py
+++ b/hammerblade/torch/tests/test_profiling.py
@@ -49,6 +49,20 @@ def test_execution_time_2():
     assert stack.find("at::Tensor& at::native::legacy::cpu::_th_normal_(at::Tensor&, double, double, at::Generator*)") != -1
     assert stack.find("at::native::add_stub::add_stub()") != -1
 
+def test_execution_time_3():
+    x = torch.ones(100000)
+    torch.hammerblade.profiler.enable()
+    x = torch.randn(100000)
+    y = x + x
+    torch.hammerblade.profiler.disable()
+    z = x.hammerblade() + x.hammerblade()
+    stack = torch.hammerblade.profiler.exec_time.raw_stack()
+    assert stack.find("at::Tensor at::CPUType::{anonymous}::add(const at::Tensor&, const at::Tensor&, c10::Scalar)") != -1
+    assert stack.find("at::Tensor at::TypeDefault::randn(c10::IntArrayRef, const c10::TensorOptions&)") != -1
+    assert stack.find("at::Tensor at::TypeDefault::ones(c10::IntArrayRef, const c10::TensorOptions&)") == -1
+    assert stack.find("at::Tensor& at::native::legacy::cpu::_th_normal_(at::Tensor&, double, double, at::Generator*)") != -1
+    assert stack.find("at::native::add_stub::add_stub()") != -1
+
 def test_unimpl_1():
     x = torch.ones(100000)
     torch.hammerblade.profiler.enable()


### PR DESCRIPTION
This PR fixes a bug which may lead to crash in PyTorch
  - What happened -- hb_mc trimming calls are logged even outside ROI, with an empty stack record. So when you do profiling, and then run any hammerblade operators, dumping profiling data leads to an invalid stack pop.
 - The bug is fixed, and a direct test is added.

Now per operation profiling runs only if `HB_REDISPATCH` is set -- to reduce native profiling overhead