### PR TITLE
Conv2d groups

### DIFF
--- a/aten/src/ATen/native/hammerblade/Convolution.cpp
+++ b/aten/src/ATen/native/hammerblade/Convolution.cpp
@@ -25,11 +25,6 @@ void hb_convolution_arg_check(
         "dilation = ", dilation,
         " is not supported by HB yet.",
         " Make sure dilation is all ones.");
-
-  // Groups check
-  TORCH_CHECK(groups == 1,
-      "Grouped convolution not supported by HB yet."
-      " Make sure groups = 1.");
 }
 
 constexpr int input_batch_size_dim = 0;  // also grad_input
@@ -173,6 +168,8 @@ Tensor hb_convolution_forward(
   device_args.push_back(create_device_tensor(*weight, device_ptrs));
   device_args.push_back(create_device_vector(padding, true, device_ptrs));
   device_args.push_back(create_device_vector(stride, true, device_ptrs));
+  device_args.push_back(create_device_scalar(
+                        safe_downcast<uint32_t, uint64_t>(groups)));
 
   c10::hammerblade::offload_kernel(
       "tensorlib_convolution_forward", device_args);

--- a/aten/src/ATen/native/hammerblade/Hardtanh.cpp
+++ b/aten/src/ATen/native/hammerblade/Hardtanh.cpp
@@ -6,7 +6,7 @@
 namespace at {
 namespace native {
   Tensor hardtanh_hb(Tensor const& self, Scalar min, Scalar max) {
-    auto out = at::empty({0}, self.options());
+    auto out = at::empty(self.sizes(), self.options());
 
     std::vector<Tensor> args;
     args.push_back(out);
@@ -15,6 +15,6 @@ namespace native {
     scalars.push_back(create_device_scalar(min));
     scalars.push_back(create_device_scalar(max));
     offload_tensor_scalar_impl(args, scalars, "tensorlib_hardtanh");
-    return self;
+    return out;
   }
 }} // at::native

--- a/aten/src/ATen/native/hammerblade/Hardtanh.cpp
+++ b/aten/src/ATen/native/hammerblade/Hardtanh.cpp
@@ -27,7 +27,7 @@ Tensor hardtanh_hb(Tensor const& self, Scalar min, Scalar max) {
   return out;
 }
 
-Tensor hardtanh_hb_(Tensor& self, Scalar min, Scalar max) {
+Tensor& hardtanh_hb_(Tensor& self, Scalar min, Scalar max) {
   _hardtanh_hb(self, self, min, max);
   return self;
 }

--- a/aten/src/ATen/native/hammerblade/Hardtanh.cpp
+++ b/aten/src/ATen/native/hammerblade/Hardtanh.cpp
@@ -5,9 +5,10 @@
 
 namespace at {
 namespace native {
-  Tensor hardtanh_hb(Tensor const& self, Scalar min, Scalar max) {
-    auto out = at::empty(self.sizes(), self.options());
 
+namespace {
+  void _hardtanh_hb(Tensor& out, Tensor const& self,
+                   Scalar min, Scalar max) {
     std::vector<eva_t> device_args;
     std::vector<eva_t> device_ptrs;
     device_args.push_back(create_device_tensor(out, device_ptrs));
@@ -17,7 +18,17 @@ namespace native {
     c10::hammerblade::offload_kernel(
         "tensorlib_hardtanh", device_args);
     cleanup_device(device_args, device_ptrs);
-
-    return out;
   }
+}
+
+Tensor hardtanh_hb(Tensor const& self, Scalar min, Scalar max) {
+  auto out = at::empty(self.sizes(), self.options());
+  _hardtanh_hb(out, self, min, max);
+  return out;
+}
+
+Tensor hardtanh_hb_(Tensor const& self, Scalar min, Scalar max) {
+  _hardtanh_hb(self, self, min, max);
+  return self;
+}
 }} // at::native

--- a/aten/src/ATen/native/hammerblade/Hardtanh.cpp
+++ b/aten/src/ATen/native/hammerblade/Hardtanh.cpp
@@ -27,7 +27,7 @@ Tensor hardtanh_hb(Tensor const& self, Scalar min, Scalar max) {
   return out;
 }
 
-Tensor hardtanh_hb_(Tensor const& self, Scalar min, Scalar max) {
+Tensor hardtanh_hb_(Tensor& self, Scalar min, Scalar max) {
   _hardtanh_hb(self, self, min, max);
   return self;
 }

--- a/aten/src/ATen/native/hammerblade/Hardtanh.cpp
+++ b/aten/src/ATen/native/hammerblade/Hardtanh.cpp
@@ -1,0 +1,20 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/hammerblade/HammerBladeContext.h>
+#include <ATen/native/hammerblade/Offload.h>
+
+namespace at {
+namespace native {
+  Tensor hardtanh_hb(Tensor const& self, Scalar min, Scalar max) {
+    auto out = at::empty({0}, self.options());
+
+    std::vector<Tensor> args;
+    args.push_back(out);
+    args.push_back(self);
+    std::vector<eva_t> scalars;
+    scalars.push_back(create_device_scalar(min));
+    scalars.push_back(create_device_scalar(max));
+    offload_tensor_scalar_impl(args, scalars, "tensorlib_hardtanh");
+    return self;
+  }
+}} // at::native

--- a/aten/src/ATen/native/hammerblade/Hardtanh.cpp
+++ b/aten/src/ATen/native/hammerblade/Hardtanh.cpp
@@ -8,13 +8,16 @@ namespace native {
   Tensor hardtanh_hb(Tensor const& self, Scalar min, Scalar max) {
     auto out = at::empty(self.sizes(), self.options());
 
-    std::vector<Tensor> args;
-    args.push_back(out);
-    args.push_back(self);
-    std::vector<eva_t> scalars;
-    scalars.push_back(create_device_scalar(min));
-    scalars.push_back(create_device_scalar(max));
-    offload_tensor_scalar_impl(args, scalars, "tensorlib_hardtanh");
+    std::vector<eva_t> device_args;
+    std::vector<eva_t> device_ptrs;
+    device_args.push_back(create_device_tensor(out, device_ptrs));
+    device_args.push_back(create_device_tensor(self, device_ptrs));
+    device_args.push_back(create_device_scalar(min.to<float>()));
+    device_args.push_back(create_device_scalar(max.to<float>()));
+    c10::hammerblade::offload_kernel(
+        "tensorlib_hardtanh", device_args);
+    cleanup_device(device_args, device_ptrs);
+
     return out;
   }
 }} // at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5592,6 +5592,7 @@
   dispatch:
     CPU: legacy::cpu::_thnn_hardtanh_forward_
     CUDA: legacy::cuda::_thnn_hardtanh_forward_
+    HammerBlade: hardtanh_hb_
 
 - func: leaky_relu.out(Tensor self, Scalar negative_slope=0.01, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5572,6 +5572,7 @@
   dispatch:
     CPU: legacy::cpu::_thnn_hardtanh_forward
     CUDA: legacy::cuda::_thnn_hardtanh_forward
+    HammerBlade: hardtanh_hb
 
 - func: hardtanh_backward.grad_input(Tensor grad_output, Tensor self, Scalar min_val, Scalar max_val, *, Tensor(a!) grad_input) -> Tensor(a!)
   python_module: nn

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -59,7 +59,7 @@ static int convolution_forward(
         size_t co = co_ + cout_per_group * group;
 
         // Load the filter w(co, ci, :, :) to dmem
-        uint32_t w_offset = w.offset(co, ci / groups, 0, 0);
+        uint32_t w_offset = w.offset(co, ci % cin_per_group, 0, 0);
         auto w_ptr = (bsg_attr_remote float*) w.data_ptr();
         load_weights(W_local, w_ptr, w_offset, Kh, Kw);
 

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -35,6 +35,7 @@ static int convolution_forward(
   auto Ph = p[0];
   auto Pw = p[1];
 
+  auto cin_per_group = Cin / groups;
   auto cout_per_group = Cout / groups;
 
   // Weights buffer
@@ -52,7 +53,7 @@ static int convolution_forward(
 
   for(uint32_t n = 0; n < N; ++n) {
     for(uint32_t ci = 0; ci < Cin; ++ci) { // input channel first to maximum data reuse
-      size_t group = ci / (Cin / groups);
+      size_t group = ci / cin_per_group;
       hb_blocked_for(bsg_tiles_X * bsg_tiles_Y, cout_per_group,
                     [&](size_t co_, size_t tg_size_co) {
         size_t co = co_ + cout_per_group * group;
@@ -114,7 +115,7 @@ static int convolution_forward(
               uint32_t kw_local = w_off;
 
               for(uint32_t kw = 0; kw < Kw; ++kw) {
-                if((ci + kh + kw) == 0) {
+                if((ci % cin_per_group + kh + kw) == 0) {
                   y(n, co, yh, yw) = 0.0;
                 }
 

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -56,11 +56,9 @@ static int convolution_forward(
       hb_blocked_for(bsg_tiles_X * bsg_tiles_Y, cout_per_group,
                     [&](size_t co_, size_t tg_size_co) {
         size_t co = co_ + cout_per_group * group;
-        bsg_printf("tile: %d ci: %d co: %d\n",
-                   __bsg_id, ci, co);
 
         // Load the filter w(co, ci, :, :) to dmem
-        uint32_t w_offset = w.offset(co, ci, 0, 0);
+        uint32_t w_offset = w.offset(co, ci / groups, 0, 0);
         auto w_ptr = (bsg_attr_remote float*) w.data_ptr();
         load_weights(W_local, w_ptr, w_offset, Kh, Kw);
 

--- a/hammerblade/torch/kernel/kernel_conv.cpp
+++ b/hammerblade/torch/kernel/kernel_conv.cpp
@@ -255,7 +255,8 @@ extern "C" {
           hb_tensor_t* input,
           hb_tensor_t* weight,
           hb_vector_t* padding,
-          hb_vector_t* strides) {
+          hb_vector_t* strides,
+          uint32_t* groups) {
     #define CONV_FORWARD_TEMPLATED(                                        \
         N, Cout, Hout, Wout, Cin, Hin, Win, Kh, Kw, Sh, Sw, Ph, Pw)        \
       if(!convolution_forward_template<                                    \
@@ -271,6 +272,8 @@ extern "C" {
     CONV_FORWARD_TEMPLATED(N,  64, 16, 16, 32, 16, 16, 1, 1, 1, 1, 0, 0);
     CONV_FORWARD_TEMPLATED(N, 128,  8,  8, 64,  8,  8, 3, 3, 1, 1, 1, 1);
     CONV_FORWARD_TEMPLATED(N, 128,  8,  8, 64,  8,  8, 1, 1, 1, 1, 0, 0);
+
+    bsg_printf("groups: %d\n", *groups);
 
     return convolution_forward(output, input, weight, padding, strides);
   };
@@ -393,7 +396,7 @@ extern "C" {
 
   HB_EMUL_REG_KERNEL(tensorlib_convolution_forward,
      hb_tensor_t*, hb_tensor_t*, hb_tensor_t*,
-     hb_vector_t*, hb_vector_t*);
+     hb_vector_t*, hb_vector_t*, uint32_t*);
 
   HB_EMUL_REG_KERNEL(tensorlib_convolution_add_bias,
      hb_tensor_t*, hb_tensor_t*);

--- a/hammerblade/torch/kernel/kernel_hardtanh.cpp
+++ b/hammerblade/torch/kernel/kernel_hardtanh.cpp
@@ -1,0 +1,28 @@
+//====================================================================
+// Element-wise hardtanh kernel
+// 03/06/2020 Bandhav Veluri
+//====================================================================
+
+#include <kernel_common.hpp>
+#include <cmath>
+
+extern "C" {
+
+//====================================================================
+// tensorlib_hardtanh
+//====================================================================
+// This is the tanh kernel for tensors with float elements.
+
+__attribute__ ((noinline))
+int tensorlib_hardtanh(hb_tensor_t* out, hb_tensor_t* t0_p,
+                       float* min, float* max)
+{
+  bsg_printf("Running tensorlib_hardtanh\n");
+  bsg_cuda_print_stat_kernel_end();
+  return 0;
+}
+
+HB_EMUL_REG_KERNEL(tensorlib_hardtanh, hb_tensor_t*, 
+                   hb_tensor_t*, float*, float*)
+
+} /* extern C */

--- a/hammerblade/torch/kernel/kernel_hardtanh.cpp
+++ b/hammerblade/torch/kernel/kernel_hardtanh.cpp
@@ -14,10 +14,28 @@ extern "C" {
 // This is the tanh kernel for tensors with float elements.
 
 __attribute__ ((noinline))
-int tensorlib_hardtanh(hb_tensor_t* out, hb_tensor_t* t0_p,
-                       float* min, float* max)
+int tensorlib_hardtanh(hb_tensor_t* t0_p, hb_tensor_t* t1_p,
+                       float* min_, float* max_)
 {
-  bsg_printf("Running tensorlib_hardtanh\n");
+  auto res = HBTensor<float>(t0_p);
+  auto input = HBTensor<float>(t1_p);
+  float max = *max_;
+  float min = *min_;
+
+  bsg_cuda_print_stat_kernel_start();
+  hb_tiled_foreach(
+    [min, max](float a) {
+      if (a < min)
+        return min;
+      else if (a > max)
+        return max;
+      else
+        return a;
+  },
+  res, input);
+
+  bsg_printf("%f\n", res(0,0));
+
   bsg_cuda_print_stat_kernel_end();
   return 0;
 }

--- a/hammerblade/torch/kernel/kernel_hardtanh.cpp
+++ b/hammerblade/torch/kernel/kernel_hardtanh.cpp
@@ -34,8 +34,6 @@ int tensorlib_hardtanh(hb_tensor_t* t0_p, hb_tensor_t* t1_p,
   },
   res, input);
 
-  bsg_printf("%f\n", res(0,0));
-
   bsg_cuda_print_stat_kernel_end();
   return 0;
 }

--- a/hammerblade/torch/kernel/kernel_hardtanh.cpp
+++ b/hammerblade/torch/kernel/kernel_hardtanh.cpp
@@ -8,11 +8,6 @@
 
 extern "C" {
 
-//====================================================================
-// tensorlib_hardtanh
-//====================================================================
-// This is the tanh kernel for tensors with float elements.
-
 __attribute__ ((noinline))
 int tensorlib_hardtanh(hb_tensor_t* t0_p, hb_tensor_t* t1_p,
                        float* min_, float* max_)

--- a/hammerblade/torch/tests/test_conv2d.py
+++ b/hammerblade/torch/tests/test_conv2d.py
@@ -11,15 +11,18 @@ import hbutils
 torch.manual_seed(42)
 random.seed(42)
 
-def _test_conv2d(inputs, kernel, padding=1, stride=1, bias=None):
+def _test_conv2d(inputs, kernel, padding=1, stride=1,
+                 bias=None, groups=1):
     inputs_hb = hbutils.init_hb_tensor(inputs)
     kernel_hb = hbutils.init_hb_tensor(kernel)
     bias_hb = None if bias is None else hbutils.init_hb_tensor(bias)
 
     conv_result_hb = F.conv2d(inputs_hb, kernel_hb,
-                              padding=padding, stride=stride, bias=bias_hb)
+                              padding=padding, stride=stride,
+                              bias=bias_hb, groups=groups)
     conv_result = F.conv2d(inputs, kernel,
-                           padding=padding, stride=stride, bias=bias)
+                           padding=padding, stride=stride,
+                           bias=bias, groups=groups)
 
     # test forward
     assert torch.allclose(conv_result, conv_result_hb.cpu())

--- a/hammerblade/torch/tests/test_conv2d.py
+++ b/hammerblade/torch/tests/test_conv2d.py
@@ -167,12 +167,39 @@ def test_conv2d_bias_4():
 
 def test_conv2d_groups_1():
     """
-    Multi-batch, multi-channel
+    Depthwise convolution
     """
     kernel = torch.rand(3, 1, 3, 3)
     inputs = torch.rand(1, 3, 5, 5)
 
     _test_conv2d(inputs, kernel, groups=3)
+
+def test_conv2d_groups_2():
+    """
+    Multi-batch, depthwise convolution
+    """
+    kernel = torch.rand(3, 1, 3, 3)
+    inputs = torch.rand(2, 3, 5, 5)
+
+    _test_conv2d(inputs, kernel, groups=3)
+
+def test_conv2d_groups_3():
+    """
+    Output groups
+    """
+    kernel = torch.rand(6, 1, 3, 3)
+    inputs = torch.rand(1, 2, 5, 5)
+
+    _test_conv2d(inputs, kernel, groups=2)
+
+def test_conv2d_groups_4():
+    """
+    Output groups
+    """
+    kernel = torch.rand(6, 2, 3, 3)
+    inputs = torch.rand(1, 4, 5, 5)
+
+    _test_conv2d(inputs, kernel, groups=2)
 
 @pytest.mark.skipif(torch.hb_cosim_on, reason="Prohibitively slow on cosim")
 def test_conv2d_batch_input_output():

--- a/hammerblade/torch/tests/test_conv2d.py
+++ b/hammerblade/torch/tests/test_conv2d.py
@@ -194,12 +194,25 @@ def test_conv2d_groups_3():
 
 def test_conv2d_groups_4():
     """
-    Output groups
+    Input & Output groups
     """
     kernel = torch.rand(6, 2, 3, 3)
     inputs = torch.rand(1, 4, 5, 5)
 
     _test_conv2d(inputs, kernel, groups=2)
+
+def test_conv2d_groups_5():
+    """
+    Grouped convolution with asymmetric padding and strides
+    """
+    kernel = torch.rand(4, 1, 3, 3)
+    inputs = torch.rand(1, 2, 5, 5)
+    padding = (2, 3)
+    stride = (1, 2)
+    bias = torch.rand(4, requires_grad=True)
+
+    _test_conv2d(inputs, kernel, padding, stride,
+                 bias, groups=2)
 
 @pytest.mark.skipif(torch.hb_cosim_on, reason="Prohibitively slow on cosim")
 def test_conv2d_batch_input_output():

--- a/hammerblade/torch/tests/test_conv2d.py
+++ b/hammerblade/torch/tests/test_conv2d.py
@@ -25,7 +25,7 @@ def _test_conv2d(inputs, kernel, padding=1, stride=1,
                            bias=bias, groups=groups)
 
     # test forward
-    assert torch.allclose(conv_result, conv_result_hb.cpu())
+    assert torch.allclose(conv_result, conv_result_hb.cpu(), rtol=1e-5)
 
     # test backward
     if inputs.requires_grad:
@@ -164,6 +164,15 @@ def test_conv2d_bias_4():
     bias = torch.rand(3, requires_grad=True)
 
     _test_conv2d(inputs, kernel, padding, stride, bias)
+
+def test_conv2d_groups_1():
+    """
+    Multi-batch, multi-channel
+    """
+    kernel = torch.rand(3, 1, 3, 3)
+    inputs = torch.rand(1, 3, 5, 5)
+
+    _test_conv2d(inputs, kernel, groups=3)
 
 @pytest.mark.skipif(torch.hb_cosim_on, reason="Prohibitively slow on cosim")
 def test_conv2d_batch_input_output():

--- a/hammerblade/torch/tests/test_hardtanh.py
+++ b/hammerblade/torch/tests/test_hardtanh.py
@@ -2,21 +2,22 @@
 tests for hardtanh
 Bandhav Veluri
 """
-
 import torch
 
-def _test_hardtanh_(x, min, max):
+def _test_hardtanh_(x, min, max, inplace=False):
     h = x.hammerblade()
-    assert h is not x
-    out_cpu = torch.nn.functional.hardtanh(x, min, max)
-    out = torch.nn.functional.hardtanh(h, min, max)
-    assert out.is_hammerblade
+    out_cpu = torch.nn.functional.hardtanh(x, min,
+                                           max, inplace)
+    out = torch.nn.functional.hardtanh(h, min,
+                                       max, inplace)
     assert torch.allclose(out.cpu(), out_cpu)
+    assert torch.allclose(h.cpu(), x)
 
 def _test_hardtanh(x):
-    _test_hardtanh_(x, 0, 0)
-    _test_hardtanh_(x, -0.5, 0.5)
-    _test_hardtanh_(x, -1, 1)
+    for inplace in [True, False]:
+        _test_hardtanh_(x, 0, 0, inplace)
+        _test_hardtanh_(x, -0.5, 0.5, inplace)
+        _test_hardtanh_(x, -1, 1, inplace)
 
 def test_hardtanh_1():
     a = torch.randn(10)

--- a/hammerblade/torch/tests/test_hardtanh.py
+++ b/hammerblade/torch/tests/test_hardtanh.py
@@ -1,0 +1,31 @@
+"""
+tests for hardtanh
+Bandhav Veluri
+"""
+
+import torch
+
+def _test_hardtanh_(x, min, max):
+    h = x.hammerblade()
+    assert h is not x
+    out_cpu = torch.nn.functional.hardtanh(x, min, max)
+    out = torch.nn.functional.hardtanh(h, min, max)
+    assert out.is_hammerblade
+    assert torch.allclose(out.cpu(), out_cpu)
+
+def _test_hardtanh(x):
+    _test_hardtanh_(x, 0, 0)
+    _test_hardtanh_(x, -0.5, 0.5)
+    _test_hardtanh_(x, -1, 1)
+
+def test_hardtanh_1():
+    a = torch.randn(10)
+    _test_hardtanh(a)
+
+def test_hardtanh_2():
+    a = torch.rand(1, 128)
+    _test_hardtanh(a)
+
+def test_hardtanh_3():
+    a = torch.rand(16, 32)
+    _test_hardtanh(a)


### PR DESCRIPTION
- This implements a conv2d variant called "grouped convolution". A special case of grouped convolution, where `input channels == groups` is called depthwise convolution. Depthwise convolutional layers are characteristic components of many modern CNNs with sota accuracy vs model complexity trade-off.
- Implemented as extension of original conv2d implementation retaining all the optimizations up until this point as well as handling all the corner cases.
- Tested on cosim.