### PR TITLE
mse_loss, pow (tensor-scalar) and mse_backward kernels

### DIFF
--- a/aten/src/ATen/native/hammerblade/MSE.cpp
+++ b/aten/src/ATen/native/hammerblade/MSE.cpp
@@ -1,0 +1,22 @@
+#include <ATen/Dispatch.h>
+#include <ATen/hammerblade/HammerBladeContext.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/BinaryOps.h>
+#include <ATen/native/hammerblade/Offload.h>
+
+namespace at { namespace native {
+namespace {
+
+static void mse_kernel_hb(TensorIterator& iter) {
+
+  AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "mse_hb", [&](){
+        offload_op_binary(iter, "tensorlib_mse");
+        });
+
+}
+
+} // anonymous namespace
+
+REGISTER_HAMMERBLADE_DISPATCH(mse_stub, &mse_kernel_hb);
+
+}} // namespace at::native

--- a/aten/src/ATen/native/hammerblade/MSEBackward.cpp
+++ b/aten/src/ATen/native/hammerblade/MSEBackward.cpp
@@ -1,0 +1,24 @@
+#include <ATen/ATen.h>
+#include <ATen/Dispatch.h>
+#include <ATen/hammerblade/HammerBladeContext.h>
+#include <ATen/native/PointwiseOps.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/hammerblade/Offload.h>
+
+namespace at {
+namespace native {
+namespace {
+
+static void mse_backward_kernel_hb(TensorIterator& iter, Scalar value) {
+  AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "mse_backward_hb", [&]() {
+    offload_op_ternary(iter, value.to<scalar_t>(), "tensorlib_mse_backward");
+  });
+}
+
+
+} // anonymous namespace
+
+REGISTER_HAMMERBLADE_DISPATCH(mse_backward_stub, &mse_backward_kernel_hb);
+
+} // namespace native
+} // namespace at

--- a/aten/src/ATen/native/hammerblade/PowTensorScalar.cpp
+++ b/aten/src/ATen/native/hammerblade/PowTensorScalar.cpp
@@ -1,0 +1,24 @@
+#include <ATen/Dispatch.h>
+#include <ATen/hammerblade/HammerBladeContext.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/Pow.h>
+#include <ATen/native/hammerblade/Offload.h>
+
+namespace at { namespace native {
+namespace {
+
+static void pow_tensor_scalar_kernel_hb(TensorIterator& iter, Scalar exp_scalar) {
+
+
+  // NOTE: Complex inputs are not supported
+  AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "pow_tensor_scalar_kernel_hb", [&](){
+        offload_op_unary(iter, exp_scalar.to<scalar_t>(), "tensorlib_pow_tensor_scalar");
+        });
+
+}
+
+} // anonymous namespace
+
+REGISTER_HAMMERBLADE_DISPATCH(pow_tensor_scalar_stub, &pow_tensor_scalar_kernel_hb);
+
+}} // namespace at::native

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3080,6 +3080,7 @@
   dispatch:
     CPU: pow_out
     CUDA: pow_out
+    HammerBlade: pow_out
     SparseCPU: pow_out_sparse_scalar
     SparseCUDA: pow_out_sparse_scalar
 
@@ -3090,6 +3091,7 @@
   dispatch:
     CPU: pow
     CUDA: pow
+    HammerBlade: pow
     SparseCPU: pow_sparse_scalar
     SparseCUDA: pow_sparse_scalar
 
@@ -4187,6 +4189,7 @@
   dispatch:
     CPU: pow_
     CUDA: pow_
+    HammerBlade: pow_
 
 - func: pow_.Tensor(Tensor(a!) self, Tensor exponent) -> Tensor(a!)
   supports_named_tensor: True

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -5353,6 +5353,7 @@
   dispatch:
     CPU: mse_loss_backward_out
     CUDA: mse_loss_backward_out
+    HammerBlade: mse_loss_backward_out
 
 - func: mse_loss_backward(Tensor grad_output, Tensor self, Tensor target, int reduction) -> Tensor
   use_c10_dispatcher: full
@@ -5360,6 +5361,7 @@
   dispatch:
     CPU: mse_loss_backward
     CUDA: mse_loss_backward
+    HammerBlade: mse_loss_backward
 
 - func: l1_loss.out(Tensor self, Tensor target, int reduction=Mean, *, Tensor(a!) out) -> Tensor(a!)
   python_module: nn

--- a/hammerblade/torch/kernel/kernel_mse.cpp
+++ b/hammerblade/torch/kernel/kernel_mse.cpp
@@ -1,0 +1,42 @@
+//====================================================================
+// MSE kernel
+// 08/10/2021 Niklas Schmelzle (jms854@cornell.edu)
+//====================================================================
+
+#include <kernel_common.hpp>
+
+extern "C" {
+
+  __attribute__ ((noinline))  int tensorlib_mse(
+          hb_tensor_t* t0_p,
+          hb_tensor_t* t1_p,
+          hb_tensor_t* t2_p) {
+
+    auto a = HBTensor<float>(t0_p);
+    auto b = HBTensor<float>(t1_p);
+    auto res = HBTensor<float>(t2_p);
+
+    // Start profiling
+    bsg_cuda_print_stat_kernel_start();
+    bsg_saif_start();
+
+    hb_tiled_foreach(
+      [](float a, float b){
+        a = a - b;
+        a = a * a;
+        return a;
+      },
+      a, b, res);
+
+    // End profiling
+    bsg_saif_end();
+    bsg_cuda_print_stat_kernel_end();
+
+    g_barrier.sync();
+    return 0;
+  }
+
+  HB_EMUL_REG_KERNEL(tensorlib_mse, hb_tensor_t*, hb_tensor_t*, hb_tensor_t*)
+
+}
+

--- a/hammerblade/torch/kernel/kernel_mse_backward.cpp
+++ b/hammerblade/torch/kernel/kernel_mse_backward.cpp
@@ -1,0 +1,44 @@
+//====================================================================
+// MSE backward kernel
+// 08/18/2021 Niklas Schmelzle (jms854@cornell.edu)
+//====================================================================
+
+#include <kernel_common.hpp>
+
+// We wrap all external-facing C++ kernels with `extern "C"` to
+// prevent name mangling
+
+extern "C" {
+
+  __attribute__ ((noinline))  int tensorlib_mse_backward(
+          hb_tensor_t* t0_p,
+          hb_tensor_t* t1_p,
+          hb_tensor_t* t2_p,
+          hb_tensor_t* t3_p,
+          float* value_p) {
+    auto res = HBTensor<float>(t0_p);
+    auto input = HBTensor<float>(t1_p);
+    auto target = HBTensor<float>(t2_p);
+    auto grad_output = HBTensor<float>(t3_p);
+    float val = *value_p;
+
+    bsg_cuda_print_stat_kernel_start();
+    bsg_saif_start();
+
+    hb_tiled_foreach(
+      [val](float self_val, float t1_val, float t2_val) {
+        return val * (self_val - t1_val) * t2_val;
+      },
+      res, input, target, grad_output);
+
+    bsg_saif_end();
+    bsg_cuda_print_stat_kernel_end();
+
+    g_barrier.sync();
+    return 0;
+  }
+
+  HB_EMUL_REG_KERNEL(tensorlib_mse_backward, hb_tensor_t*, hb_tensor_t*,
+                     hb_tensor_t*, hb_tensor_t*, float*)
+
+}

--- a/hammerblade/torch/kernel/kernel_pow_tensor_scalar.cpp
+++ b/hammerblade/torch/kernel/kernel_pow_tensor_scalar.cpp
@@ -1,0 +1,54 @@
+//====================================================================
+// power kernel for tensor with scalar exponent
+// 08/13/2021 Niklas Schmelzle (jms854@cornell.edu)
+//====================================================================
+
+#include <kernel_common.hpp>
+#include <cmath>
+
+extern "C" {
+
+  __attribute__ ((noinline))  int tensorlib_pow_tensor_scalar(
+          hb_tensor_t* _base,
+          hb_tensor_t* _result,
+          float* _exp_scalar) {
+    auto base = HBTensor<float>(_base);
+    auto result = HBTensor<float>(_result);
+    float exp = *_exp_scalar;
+
+
+    bsg_cuda_print_stat_kernel_start();
+    bsg_saif_start();
+
+    hb_tiled_foreach(
+      [exp](float b) {
+        // similar to aten/src/ATen/native/cpu/PowKernel.cpp
+        if (exp == 0.5) {
+          return (float) std::sqrt(b);
+        } else if (exp == 2.0) {
+          return b*b;
+        } else if (exp == 3.0) {
+          return b*b*b;
+        } else if (exp == -0.5) {
+          return (float) (1.0 / std::sqrt(b));
+        } else if (exp == -1.0) {
+          return (float) (1.0 / b);
+        } else if (exp == -2.0) {
+          return (float) (1.0 / (b*b));
+        } else {
+          return (float) std::pow(b, exp);
+        }
+       },
+       base, result);
+
+    bsg_saif_end();
+    bsg_cuda_print_stat_kernel_end();
+
+    g_barrier.sync();
+    return 0;
+  }
+
+  HB_EMUL_REG_KERNEL(tensorlib_pow_tensor_scalar, hb_tensor_t*, hb_tensor_t*,
+                     float*)
+
+}

--- a/hammerblade/torch/tests/test_mse_backward.py
+++ b/hammerblade/torch/tests/test_mse_backward.py
@@ -1,0 +1,70 @@
+"""
+Tests on mse_backward operation
+08/18/2021 Niklas Schmelzle (jms854@cornell.edu)
+"""
+import torch
+import torch.nn as nn
+from random import randrange
+import numpy as np
+
+def _test_mse_backward(inp_list, target_list, target_requires_grad=False):
+    loss = nn.MSELoss()
+
+    inp = torch.tensor(inp_list, requires_grad=True)
+    inph = torch.tensor(inp_list, requires_grad=True, device='hammerblade')
+
+    target = torch.tensor(target_list, requires_grad=target_requires_grad)
+    targeth = torch.tensor(target_list, requires_grad=target_requires_grad, device='hammerblade')
+
+    out = loss(inp, target)
+    outh = loss(inph, targeth)
+
+    print("out:")
+    print(out)
+    print(outh)
+
+    out.backward()
+    outh.backward()
+
+    print("gradient:")
+    print(inp.grad)
+    print(inph.grad)
+
+    assert outh.device == torch.device("hammerblade")
+    assert torch.allclose(inp.grad, inph.grad.cpu())
+
+
+def test_mse_backward1():
+    inp_list = [3.7]
+    target_list = [3.0]
+    _test_mse_backward(inp_list, target_list)
+
+def test_mse_backward2():
+    inp_list = [3.7, 5.5, 27.0, 3.9, -2.2]
+    target_list = [3.0, 6.7, 26.9, 5.0, -3.0]
+    _test_mse_backward(inp_list, target_list)
+
+def test_mse_backward3():
+    list_size = randrange(1, 1000)
+    inp_list = np.random.rand(list_size).tolist()
+    target_list = np.random.rand(list_size).tolist()
+    _test_mse_backward(inp_list, target_list)
+
+
+# following tests do not require mse_backward kernel
+# since forward pass is implemented as python pytorch kernel
+def test_mse_backward_target_grad1():
+    inp_list = [3.7]
+    target_list = [3.0]
+    _test_mse_backward(inp_list, target_list, target_requires_grad=True)
+
+def test_mse_backward_target_grad2():
+    inp_list = [3.7, 5.5, 27.0, 3.9, -2.2]
+    target_list = [3.0, 6.7, 26.9, 5.0, -3.0]
+    _test_mse_backward(inp_list, target_list, target_requires_grad=True)
+
+def test_mse_backward_target_grad3():
+    list_size = randrange(1, 1000)
+    inp_list = np.random.rand(list_size).tolist()
+    target_list = np.random.rand(list_size).tolist()
+    _test_mse_backward(inp_list, target_list, target_requires_grad=True)

--- a/hammerblade/torch/tests/test_mse_loss.py
+++ b/hammerblade/torch/tests/test_mse_loss.py
@@ -1,0 +1,50 @@
+"""
+Tests on mse_loss
+08/10/2021 Niklas Schmelzle (jms854@cornell.edu)
+"""
+import torch
+import torch.nn as nn
+
+from random import randrange
+import numpy as np
+
+def _test_mse_loss(inp_list, target_list, target_requires_grad=False):
+    loss = nn.MSELoss()
+
+    inp = torch.tensor(inp_list)
+    inph = inp.hammerblade()
+    target = torch.tensor(target_list, requires_grad=target_requires_grad)
+    targeth = target.hammerblade()
+
+    output = loss(inp, target)
+    outputh = loss(inph, targeth)
+    print()
+    print("output: ")
+    print(output)
+    print("outputh: ")
+    print(outputh)
+    assert outputh.device == torch.device("hammerblade")
+    assert torch.allclose(output, outputh.cpu())
+
+
+# target without gradient
+def test_mse_loss1():
+    _test_mse_loss([2.0], [2.5])
+
+def test_mse_loss2():
+    _test_mse_loss([1.0, 7.0, -3.0], [2.0, 5.0, -1.0])
+
+def test_mse_loss3():
+    x_size = randrange(50)
+    y_size = randrange(10)
+
+    inp = [1.0]
+    target = [1.0]
+    if y_size == 1:
+        inp = np.random.rand(x_size).tolist()
+        target = np.random.rand(x_size).tolist()
+    else:
+        inp = np.random.rand(y_size, x_size).tolist()
+        target = np.random.rand(y_size, x_size).tolist()
+
+    _test_mse_loss(inp, target)

--- a/hammerblade/torch/tests/test_mse_loss.py
+++ b/hammerblade/torch/tests/test_mse_loss.py
@@ -27,12 +27,12 @@ def _test_mse_loss(inp_list, target_list, target_requires_grad=False):
     assert torch.allclose(output, outputh.cpu())
 
 
-# target without gradient
+# target does not require gradient
 def test_mse_loss1():
-    _test_mse_loss([2.0], [2.5])
+    _test_mse_loss([2.0], [2.5], False)
 
 def test_mse_loss2():
-    _test_mse_loss([1.0, 7.0, -3.0], [2.0, 5.0, -1.0])
+    _test_mse_loss([1.0, 7.0, -3.0], [2.0, 5.0, -1.0], False)
 
 def test_mse_loss3():
     x_size = randrange(50)
@@ -47,4 +47,28 @@ def test_mse_loss3():
         inp = np.random.rand(y_size, x_size).tolist()
         target = np.random.rand(y_size, x_size).tolist()
 
-    _test_mse_loss(inp, target)
+    _test_mse_loss(inp, target, False)
+
+
+# target requires gradient
+# pow (tensor-scalar) kernel is also utilized
+def test_mse_loss_grad1():
+    _test_mse_loss([2.0], [2.5], True)
+
+def test_mse_loss_grad2():
+    _test_mse_loss([1.0, 7.0, -3.0], [2.0, 5.0, -1.0], True)
+
+def test_mse_loss_grad3():
+    x_size = randrange(50)
+    y_size = randrange(10)
+
+    inp = [1.0]
+    target = [1.0]
+    if y_size == 1:
+        inp = np.random.rand(x_size).tolist()
+        target = np.random.rand(x_size).tolist()
+    else:
+        inp = np.random.rand(y_size, x_size).tolist()
+        target = np.random.rand(y_size, x_size).tolist()
+
+    _test_mse_loss(inp, target, True)

--- a/hammerblade/torch/tests/test_mse_loss.py
+++ b/hammerblade/torch/tests/test_mse_loss.py
@@ -24,7 +24,7 @@ def _test_mse_loss(inp_list, target_list, target_requires_grad=False):
     print("outputh: ")
     print(outputh)
     assert outputh.device == torch.device("hammerblade")
-    assert torch.allclose(output, outputh.cpu())
+    assert torch.allclose(output, outputh.cpu(), equal_nan=True)
 
 
 # target does not require gradient

--- a/hammerblade/torch/tests/test_mse_loss.py
+++ b/hammerblade/torch/tests/test_mse_loss.py
@@ -24,7 +24,7 @@ def _test_mse_loss(inp_list, target_list, target_requires_grad=False):
     print("outputh: ")
     print(outputh)
     assert outputh.device == torch.device("hammerblade")
-    assert torch.allclose(output, outputh.cpu(), equal_nan=True)
+    assert torch.allclose(output, outputh.cpu())
 
 
 # target does not require gradient
@@ -35,8 +35,8 @@ def test_mse_loss2():
     _test_mse_loss([1.0, 7.0, -3.0], [2.0, 5.0, -1.0], False)
 
 def test_mse_loss3():
-    x_size = randrange(50)
-    y_size = randrange(10)
+    x_size = randrange(1, 50)
+    y_size = randrange(1, 10)
 
     inp = [1.0]
     target = [1.0]
@@ -59,8 +59,8 @@ def test_mse_loss_grad2():
     _test_mse_loss([1.0, 7.0, -3.0], [2.0, 5.0, -1.0], True)
 
 def test_mse_loss_grad3():
-    x_size = randrange(50)
-    y_size = randrange(10)
+    x_size = randrange(1, 50)
+    y_size = randrange(1, 10)
 
     inp = [1.0]
     target = [1.0]

--- a/hammerblade/torch/tests/test_pow_tensor_scalar.py
+++ b/hammerblade/torch/tests/test_pow_tensor_scalar.py
@@ -28,7 +28,7 @@ def test_scalar_scalar():
         _test_pow_tensor_scalar(inp_scalar, exp)
 
 def test_tensor_scalar():
-    list_size = randrange(1000)
+    list_size = randrange(1, 1000)
     inp_scalar = np.random.rand(list_size).tolist()
     for exp in [0.5, 2.0, 3.0, -0.5, -1.0, -2.0, randrange(42)]:
         _test_pow_tensor_scalar([-3.0, -0.5, 0.0, 0.3, 1.7, 17.0, 42.42, 128.0], exp)

--- a/hammerblade/torch/tests/test_pow_tensor_scalar.py
+++ b/hammerblade/torch/tests/test_pow_tensor_scalar.py
@@ -29,7 +29,7 @@ def test_scalar_scalar():
 
 def test_tensor_scalar():
     list_size = randrange(1, 1000)
-    inp_scalar = np.random.rand(list_size).tolist()
+    inp_list = np.random.rand(list_size).tolist()
     for exp in [0.5, 2.0, 3.0, -0.5, -1.0, -2.0, randrange(42)]:
         _test_pow_tensor_scalar([-3.0, -0.5, 0.0, 0.3, 1.7, 17.0, 42.42, 128.0], exp)
-        _test_pow_tensor_scalar(inp_scalar, exp)
+        _test_pow_tensor_scalar(inp_list, exp)

--- a/hammerblade/torch/tests/test_pow_tensor_scalar.py
+++ b/hammerblade/torch/tests/test_pow_tensor_scalar.py
@@ -17,6 +17,7 @@ def _test_pow_tensor_scalar(inp_list, exp_scalar):
     print(outh)
 
     assert outh.device == torch.device("hammerblade")
+    # NaN results when base negative and exp < 1
     assert torch.allclose(out, outh.cpu(), equal_nan=True)
 
 

--- a/hammerblade/torch/tests/test_pow_tensor_scalar.py
+++ b/hammerblade/torch/tests/test_pow_tensor_scalar.py
@@ -1,0 +1,34 @@
+"""
+Tests on pow_tensor_scalar (tensor base, scalar exp)
+08/17/2021 Niklas Schmelzle (jms854@cornell.edu)
+"""
+import torch
+import torch.nn as nn
+from random import randrange
+import numpy as np
+
+def _test_pow_tensor_scalar(inp_list, exp_scalar):
+    inp = torch.tensor(inp_list)
+    inph = inp.hammerblade()
+
+    out = inp ** exp_scalar
+    outh = inph ** exp_scalar
+    print(out)
+    print(outh)
+
+    assert outh.device == torch.device("hammerblade")
+    assert torch.allclose(out, outh.cpu(), equal_nan=True)
+
+
+def test_scalar_scalar():
+    inp_scalar = np.random.rand(1).tolist()
+    for exp in [0.5, 2.0, 3.0, -0.5, -1.0, -2.0, randrange(42)]:
+        _test_pow_tensor_scalar([42.42], exp)
+        _test_pow_tensor_scalar(inp_scalar, exp)
+
+def test_tensor_scalar():
+    list_size = randrange(1000)
+    inp_scalar = np.random.rand(list_size).tolist()
+    for exp in [0.5, 2.0, 3.0, -0.5, -1.0, -2.0, randrange(42)]:
+        _test_pow_tensor_scalar([-3.0, -0.5, 0.0, 0.3, 1.7, 17.0, 42.42, 128.0], exp)
+        _test_pow_tensor_scalar(inp_scalar, exp)


### PR DESCRIPTION
HammerBlade Kernels for following operations:
* mse_loss
* mse_backward
* power (Tensor base, scalar exp)

Power operation was added, since the Python implementation of [mse_loss for targets requiring gradients](https://github.com/cornell-brg/hb-pytorch/blob/084cf4d483e4adc2451d6875eb7cafd91d7ea47b/torch/nn/functional.py#L2211) requires a square operation.

Kernels are implemented similar to CPU implementation and pass tests in emulation and cosimulation.