### PR TITLE
Where operator

### DIFF
--- a/aten/src/ATen/native/hammerblade/Where.cpp
+++ b/aten/src/ATen/native/hammerblade/Where.cpp
@@ -1,0 +1,28 @@
+#include <ATen/Dispatch.h>
+#include <ATen/hammerblade/HammerBladeContext.h>
+#include <ATen/native/TensorIterator.h>
+#include <ATen/native/hammerblade/Offload.h>
+
+namespace at { namespace native {
+
+Tensor _s_where_hb(const Tensor& condition, const Tensor& self, const Tensor& other) {
+    TORCH_CHECK(self.dtype() == other.dtype(), "expected scalar type ", self.dtype(), " but found ", other.dtype());
+    Tensor result = at::empty(self.sizes(), self.options());
+
+    auto iter = at::TensorIterator();
+    iter.set_check_mem_overlap(true);
+    iter.add_output(result);
+    iter.add_input(condition);
+    iter.add_input(self);
+    iter.add_input(other);
+    iter.dont_compute_common_dtype();
+    iter.build();
+
+    AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "where_hb", [&](){
+        offload_op_ternary(iter, "tensorlib_where");
+    });
+
+    return result;
+}
+
+}}

--- a/aten/src/ATen/native/hammerblade/Where.cpp
+++ b/aten/src/ATen/native/hammerblade/Where.cpp
@@ -18,9 +18,15 @@ Tensor _s_where_hb(const Tensor& condition, const Tensor& self, const Tensor& ot
     iter.dont_compute_common_dtype();
     iter.build();
 
-    AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "where_hb", [&](){
-        offload_op_ternary(iter, "tensorlib_where");
-    });
+    if (condition.scalar_type() == at::ScalarType::Byte) {
+        AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "where_byte_hb", [&](){
+            offload_op_ternary(iter, "tensorlib_where_byte");
+        });
+    } else {
+        AT_DISPATCH_FLOAT_TYPE_ONLY(iter.dtype(), "where_bool_hb", [&](){
+            offload_op_ternary(iter, "tensorlib_where_bool");
+        });
+    }
 
     return result;
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -2919,6 +2919,7 @@
   dispatch:
     CPU: _s_where_cpu
     CUDA: _s_where_cuda
+    HammerBlade: _s_where_hb
 
 - func: norm_except_dim(Tensor v, int pow=2, int dim=0) -> Tensor
   variants: function

--- a/hammerblade/torch/kernel/hb_tensor.hpp
+++ b/hammerblade/torch/kernel/hb_tensor.hpp
@@ -87,6 +87,8 @@ class HBTensorImpl {
         HB_FIX_WAW_HAZARD(sizes);
       }
 
+    typedef DT data_type;
+
     bsg_attr_remote char* data_ptr() {
       return (bsg_attr_remote char*)data;
     }

--- a/hammerblade/torch/kernel/hb_tiled_for.hpp
+++ b/hammerblade/torch/kernel/hb_tiled_for.hpp
@@ -104,7 +104,7 @@ inline void hb_tiled_foreach(F functor,
       start, end, functor, res,
       args...,
       (bsg_attr_remote scalar_t*) res.data_ptr(),
-      ((bsg_attr_remote scalar_t*) args.data_ptr())...);
+      ((bsg_attr_remote typename decltype(args)::data_type*) args.data_ptr())...);
 }
 
 // Nullary

--- a/hammerblade/torch/kernel/hb_tiled_for.hpp
+++ b/hammerblade/torch/kernel/hb_tiled_for.hpp
@@ -12,6 +12,7 @@
 
 #include <map>
 #include <math.h>
+#include <tuple>
 #include <initializer_list>
 #include <hb_assert.hpp>
 #include <hb_tensor.hpp>
@@ -89,10 +90,10 @@ inline void calc_range(hb_range* range, size_t numel,
 // Tiled Pointwise for
 // =========================================================
 
-template<typename scalar_t, typename F, class... Types>
+template<typename F, class... Types>
 inline void hb_tiled_foreach(F functor,
-                             HBTensor<scalar_t> res,
                              Types... args) {
+  auto res = std::get<0>(std::make_tuple(args...));
   // Iterating over all elementes
   hb_range range;
   calc_range(&range, res.numel());
@@ -101,9 +102,8 @@ inline void hb_tiled_foreach(F functor,
 
   // Static dispatch based on number number of operands
   hb_tiled_foreach_impl(
-      start, end, functor, res,
+      start, end, functor,
       args...,
-      (bsg_attr_remote scalar_t*) res.data_ptr(),
       ((bsg_attr_remote typename decltype(args)::data_type*) args.data_ptr())...);
 }
 

--- a/hammerblade/torch/kernel/hb_tiled_for.hpp
+++ b/hammerblade/torch/kernel/hb_tiled_for.hpp
@@ -128,13 +128,13 @@ __attribute__((noinline)) void hb_tiled_foreach_impl(
 }
 
 // Unary
-template<typename scalar_t, typename F, typename... P>
+template<typename scalar1_t, typename scalar2_t, typename F, typename... P>
 __attribute__((noinline)) void hb_tiled_foreach_impl(
       size_t start, size_t end, F functor,
-      HBTensor<scalar_t> res,
-      HBTensor<scalar_t> tensor_arg0,
-      bsg_attr_remote scalar_t* bsg_attr_noalias res_ptr,
-      bsg_attr_remote scalar_t* bsg_attr_noalias tensor_data_ptr0) {
+      HBTensor<scalar1_t> res,
+      HBTensor<scalar2_t> tensor_arg0,
+      bsg_attr_remote scalar1_t* bsg_attr_noalias res_ptr,
+      bsg_attr_remote scalar2_t* bsg_attr_noalias tensor_data_ptr0) {
   // is_trivial_1d
   if(res.ndim() == 1) {
     bsg_unroll(16) for(size_t idx = start; idx < end; idx++) {
@@ -150,15 +150,16 @@ __attribute__((noinline)) void hb_tiled_foreach_impl(
 }
 
 // Binary
-template<typename scalar_t, typename F, typename... P>
+template<typename scalar1_t, typename scalar2_t, typename scalar3_t,
+         typename F, typename... P>
 __attribute__((noinline)) void hb_tiled_foreach_impl(
       size_t start, size_t end, F functor,
-      HBTensor<scalar_t> res,
-      HBTensor<scalar_t> tensor_arg0,
-      HBTensor<scalar_t> tensor_arg1,
-      bsg_attr_remote scalar_t* bsg_attr_noalias res_ptr,
-      bsg_attr_remote scalar_t* bsg_attr_noalias tensor_data_ptr0,
-      bsg_attr_remote scalar_t* bsg_attr_noalias tensor_data_ptr1) {
+      HBTensor<scalar1_t> res,
+      HBTensor<scalar2_t> tensor_arg0,
+      HBTensor<scalar3_t> tensor_arg1,
+      bsg_attr_remote scalar1_t* bsg_attr_noalias res_ptr,
+      bsg_attr_remote scalar2_t* bsg_attr_noalias tensor_data_ptr0,
+      bsg_attr_remote scalar3_t* bsg_attr_noalias tensor_data_ptr1) {
   // is_trivial_1d
   if(res.ndim() == 1) {
     bsg_unroll(16) for(size_t idx = start; idx < end; idx++) {
@@ -176,17 +177,18 @@ __attribute__((noinline)) void hb_tiled_foreach_impl(
 }
 
 // Ternary
-template<typename scalar_t, typename F, typename... P>
+template<typename scalar1_t, typename scalar2_t, typename scalar3_t,
+         typename scalar4_t, typename F, typename... P>
 __attribute__((noinline)) void hb_tiled_foreach_impl(
       size_t start, size_t end, F functor,
-      HBTensor<scalar_t> res,
-      HBTensor<scalar_t> tensor_arg0,
-      HBTensor<scalar_t> tensor_arg1,
-      HBTensor<scalar_t> tensor_arg2,
-      bsg_attr_remote scalar_t* bsg_attr_noalias res_ptr,
-      bsg_attr_remote scalar_t* bsg_attr_noalias tensor_data_ptr0,
-      bsg_attr_remote scalar_t* bsg_attr_noalias tensor_data_ptr1,
-      bsg_attr_remote scalar_t* bsg_attr_noalias tensor_data_ptr2) {
+      HBTensor<scalar1_t> res,
+      HBTensor<scalar2_t> tensor_arg0,
+      HBTensor<scalar3_t> tensor_arg1,
+      HBTensor<scalar4_t> tensor_arg2,
+      bsg_attr_remote scalar1_t* bsg_attr_noalias res_ptr,
+      bsg_attr_remote scalar2_t* bsg_attr_noalias tensor_data_ptr0,
+      bsg_attr_remote scalar3_t* bsg_attr_noalias tensor_data_ptr1,
+      bsg_attr_remote scalar4_t* bsg_attr_noalias tensor_data_ptr2) {
   // is_trivial_1d
   if(res.ndim() == 1) {
     bsg_unroll(16) for(size_t idx = start; idx < end; idx++) {

--- a/hammerblade/torch/kernel/kernel_where.cpp
+++ b/hammerblade/torch/kernel/kernel_where.cpp
@@ -1,0 +1,41 @@
+//====================================================================
+// where kernel
+// 09/03/2021 Niklas Schmelzle (jms854@cornell.edu)
+//====================================================================
+
+#include <kernel_common.hpp>
+
+// We wrap all external-facing C++ kernels with `extern "C"` to
+// prevent name mangling
+
+extern "C" {
+
+  __attribute__ ((noinline))  int tensorlib_where(
+          hb_tensor_t* t0_p,
+          hb_tensor_t* t1_p,
+          hb_tensor_t* t2_p,
+          hb_tensor_t* t3_p) {
+    auto res = HBTensor<float>(t0_p);
+    auto condition_ten = HBTensor<uint8_t>(t1_p);
+    auto x_ten = HBTensor<float>(t2_p);
+    auto y_ten = HBTensor<float>(t3_p);
+
+    bsg_cuda_print_stat_kernel_start();
+    bsg_saif_start();
+
+    hb_tiled_foreach(
+      [](uint8_t condition, float x, float y) {
+        return condition ? x : y;
+      },
+      res, condition_ten, x_ten, y_ten);
+
+    bsg_saif_end();
+    bsg_cuda_print_stat_kernel_end();
+
+    g_barrier.sync();
+    return 0;
+  }
+
+  HB_EMUL_REG_KERNEL(tensorlib_where, hb_tensor_t*, hb_tensor_t*,
+                     hb_tensor_t*, hb_tensor_t*)
+}

--- a/hammerblade/torch/tests/test_where.py
+++ b/hammerblade/torch/tests/test_where.py
@@ -1,0 +1,63 @@
+"""
+Tests on where operation
+09/20/2021 Niklas Schmelzle (jms854@cornell.edu)
+"""
+import torch
+import torch.nn as nn
+
+def _test_where(condition_ten, x_ten, y_ten):
+    xh_ten = x_ten.hammerblade()
+    yh_ten = y_ten.hammerblade()
+    conditionh_ten = condition_ten.hammerblade()
+
+    out = torch.where(condition_ten, x_ten, y_ten)
+    outh = torch.where(conditionh_ten, xh_ten, yh_ten)
+
+    assert outh.device == torch.device("hammerblade")
+    assert torch.allclose(out, outh.cpu())
+
+
+# condition is bool
+def test_where1():
+    x = torch.tensor([[-0.5,  2.0,  0.1],
+                      [ 1.1, -1.1, -7.0],
+                      [ 3.2, -2.1, 42.0]])
+    y = torch.ones(x.shape)
+    condition_bool = torch.tensor([[True, False, True],
+                              [False, True, False],
+                              [True, False, True]], dtype=torch.bool)
+    _test_where(condition_bool, x, y)
+
+def test_where2():
+    x = torch.tensor([[-0.5,  2.0,  0.1],
+                      [ 1.1, -1.1, -7.0],
+                      [ 3.2, -2.1, 42.0]])
+    y = torch.ones(x.shape)
+    condition_bool = x > 0.1
+    _test_where(condition_bool, x, y)
+
+def test_where3():
+    x = torch.rand(50, 50)
+    y = torch.rand(x.shape)
+    condition_bool = x > 0.5
+
+    _test_where(condition_bool, x, y)
+
+
+# condition is uint8
+def test_where4():
+    x = torch.tensor([[-0.5,  2.0,  0.1],
+                      [ 1.1, -1.1, -7.0],
+                      [ 3.2, -2.1, 42.0]])
+    y = torch.ones(x.shape)
+    condition_uint8 = torch.tensor([[0, 8, 0],
+                                    [7, 0, 9],
+                                    [0, 8, 0]], dtype=torch.uint8)
+    _test_where(condition_uint8, x, y)
+
+def test_where5():
+    x = torch.rand(50, 50)
+    y = torch.rand(x.shape)
+    condition_uint8 = torch.randint(0, 10, (x.shape), dtype=torch.uint8)
+
+    _test_where(condition_uint8, x, y)


### PR DESCRIPTION
Added where operator implementation for hammerblade;

Since the input tensors of the where operator are not all floats (conditional tensor is of type bool or uint8_t), some changes in the hb_tiled_for.hpp file were necessary. Previously, the hb_tiled_foreach functions expected all tensors to be of same type. Now, the type of each tensor is saved in the *data_type* definition of the hb_tensor class. the hb_tiled_foreach functions utilizes this definition.

Since many other operators utilize the hb_tiled_foreach procedure, the changes in the hb_tiled_for.hpp file should be checked carefully. For me it compiles fine and most pytests run successfully. 